### PR TITLE
[i386] Bug Fix: Bad Kernel Page Pool Size

### DIFF
--- a/include/target/ibm/pc.h
+++ b/include/target/ibm/pc.h
@@ -120,7 +120,7 @@
 	/**
 	 * @brief Kernel page pool size (in bytes).
 	 */
-	#define _KPOOL_SIZE 0x01000000
+	#define _KPOOL_SIZE 0x400000
 
 /*============================================================================*
  * Clock Interface                                                            *


### PR DESCRIPTION
In this commit, I have fixed the size of the kernel page pool. Before,
the I386 PC target was setting it up to 16 MB, even though only a single
page table (4 MB) was reserved for the kernel page pool at boot time.
