### PR TITLE
Enhancement: GDB Confirm Off, Quit If Connection Lost

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -27,4 +27,9 @@ layout split
 target remote localhost:1234
 handle SIGSEGV nostop noprint nopass
 symbol-file bin/kernel
-
+set confirm off
+define hook-stop
+	if $_isvoid ($_exitcode) != 1
+		quit
+	end
+end


### PR DESCRIPTION
This commit introduces two simple features proposed in #18:
- Disabled confirmation messages (y/n)
- Automatically close GDB if the VM is closed gracefully, e.g: by receiving a SIGTERM.