### PR TITLE
[or1k] OpenRISC Toolchain Enhancements

### DIFF
--- a/build/makefile.or1k-pc
+++ b/build/makefile.or1k-pc
@@ -1,0 +1,46 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#              2018 Davidson Francis     <davidsondfgl@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# OpenRISC's Toolchain Directory
+export TOOLCHAIN_DIR=$(TOOLSDIR)/dev/toolchain/or1k/bin/
+
+# Target Configuration
+export ARCH = or1k
+
+# Toolchain
+export CC = $(TOOLCHAIN_DIR)/or1k-elf-gcc
+export LD = $(TOOLCHAIN_DIR)/or1k-elf-ld
+export AR = $(TOOLCHAIN_DIR)/or1k-elf-ar
+
+# Toolchain configuration.
+export CFLAGS   = -D __or1k__ -D __pc__
+export CFLAGS  += -pedantic-errors -fextended-identifiers
+export CFLAGS  += -nostdlib -nostdinc -fno-stack-protector
+export LDFLAGS  =
+
+# Libraries
+export LIBKERNEL = libkernel-$(ARCH).a
+export LIBNANVIX = libnanvix-$(ARCH).a
+export LIBS += $(LIBDIR)/$(LIBNANVIX) $(LIBDIR)/$(LIBKERNEL)

--- a/tools/run/run-qemu.sh
+++ b/tools/run/run-qemu.sh
@@ -41,7 +41,6 @@ case "$TARGET" in
 	"or1k")
 		qemu-system-or1k       \
 			-kernel bin/kernel \
-			-nographic         \
 			-serial stdio      \
 			-display none      \
 			-m 256M            \


### PR DESCRIPTION
This PR introduces the environment variables necessary to build for the or1k-pc platform (#17). I also found a tiny bug in the run script that does not allows to run Qemu.

Furthermore, I've double checked the setup toolchain scripts for or1k and everything looks fine, ;-).