### PR TITLE
Bug Fix: i386 Boot Symbols

### DIFF
--- a/src/kernel/hal/arch/i386/boot.S
+++ b/src/kernel/hal/arch/i386/boot.S
@@ -37,10 +37,8 @@
 #define MBOOT_FLAGS (MBOOT_PAGE_ALIGN | MBOOT_MEMORY_INFO)
 
 /* Exported symbols. */
-.globl kmain
-
-/* Exported symbols. */
 .globl start
+.globl idle_pgdir
 
 /*============================================================================*
  *                              bootstrap section                             *


### PR DESCRIPTION
In this commit, I fix a bad export of symbols in the bootstrap. We were
mainly missing to export the page directory of the idle process.