### PR TITLE
[i386-pc] Bug Fix: Bad Memory Sizes

### DIFF
--- a/include/target/ibm/pc.h
+++ b/include/target/ibm/pc.h
@@ -113,14 +113,33 @@
 	/**@}*/
 
 	/**
-	 * @brief User memory size (in bytes).
+	 * @brief Memory size (in bytes).
+	 *
+	 * @cond i386-pc
 	 */
-	#define _UMEM_SIZE (16*1024*1024)
+	#define _MEMORY_SIZE (32*1024*1024)
+	/**@endcond*/
+
+	/**
+	 * @brief Kernel memory size (in bytes).
+	 */
+	#define _KMEM_SIZE (16*1024*1024)
 
 	/**
 	 * @brief Kernel page pool size (in bytes).
+	 *
+	 * @cond i386-pc
 	 */
-	#define _KPOOL_SIZE 0x400000
+	#define _KPOOL_SIZE (4*1024*1024)
+	/*@endcond*/
+
+	/**
+	 * @brief User memory size (in bytes).
+	 *
+	 * @cond i386-pc
+	 */
+	#define _UMEM_SIZE (_MEMORY_SIZE - _KMEM_SIZE - _KPOOL_SIZE)
+	/**@endcond*/
 
 /*============================================================================*
  * Clock Interface                                                            *


### PR DESCRIPTION
In this commit, I fix bad memory sizes for the i386-PC platform.
Overall, we were missing that the kernel spans over 2 Page Tables (lower
8MB) and the user memory that is available is actually computed
accordingly the size of the kernel and the size of the kernel page pool.