### PR TITLE
Bug Fix: Bad Debug Release Build

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -34,7 +34,7 @@ export CFLAGS  += -Wundef -Wshadow -Wuninitialized -Wlogical-op
 export CFLAGS  += -Wvla # -Wredundant-decls
 export CFLAGS  += -I $(INCDIR)
 ifeq ($(RELEASE), true)
-	export CFLAGS  += -O3 -NDEBUG
+	export CFLAGS  += -O3 -D NDEBUG
 else
 	export CFLAGS  += -Og -g
 endif


### PR DESCRIPTION
In this commit, I fix a small typo, for the debug release build. We were
missing the "D" to define the constant NDEBUG.