### PR TITLE
Bug Fix: Removing Initial RAM Disk Check

### DIFF
--- a/include/nanvix/hal/target.h
+++ b/include/nanvix/hal/target.h
@@ -173,10 +173,6 @@
 	#error "_KPOOL_VIRT not defined"
 	#endif
 
-	#ifndef _INITRD_VIRT
-	#error "_INITRD_VIRT not defined"
-	#endif
-
 	#ifndef _KBASE_PHYS
 	#error "_KBASE_PHYS not defined"
 	#endif

--- a/include/nanvix/mm.h
+++ b/include/nanvix/mm.h
@@ -43,11 +43,10 @@
 	 * @name Virtual Memory Layout
 	 */
 	/**@{*/
-	#define UBASE_VIRT  _UBASE_VIRT  /**< User Base         */
-	#define USTACK_ADDR _USTACK_ADDR /**< User Stack        */
-	#define KBASE_VIRT  _KBASE_VIRT  /**< Kernel Base       */
-	#define KPOOL_VIRT  _KPOOL_VIRT  /**< Kernel Page Pool  */
-	#define INITRD_VIRT _INITRD_VIRT /**< Initial RAM disk. */
+	#define UBASE_VIRT  _UBASE_VIRT  /**< User Base        */
+	#define USTACK_ADDR _USTACK_ADDR /**< User Stack       */
+	#define KBASE_VIRT  _KBASE_VIRT  /**< Kernel Base      */
+	#define KPOOL_VIRT  _KPOOL_VIRT  /**< Kernel Page Pool */
 	/**@}*/
 
 	/**

--- a/include/target/ibm/pc.h
+++ b/include/target/ibm/pc.h
@@ -100,7 +100,6 @@
 	#define _USTACK_ADDR 0xc0000000 /**< User stack.       */
 	#define _KBASE_VIRT  0xc0000000 /**< Kernel base.      */
 	#define _KPOOL_VIRT  0xc1000000 /**< Kernel page pool. */
-	#define _INITRD_VIRT 0xc2000000 /**< Initial RAM disk. */
 	/**@}*/
 
 	/**


### PR DESCRIPTION
In this commit, I removed the initial RAM disk (initrd) check for the
HAL. We don't have one yet, so implemented HALs should not get bothered
about it.