### PR TITLE
Bug Fix: Bad Kernel Page Pool Address Checking

### DIFF
--- a/src/kernel/mm/mm.c
+++ b/src/kernel/mm/mm.c
@@ -55,7 +55,7 @@
 /*
  * User address space cannot overlap with kernel page pool.
  */
-#if ((UBASE_VIRT >= KPOOL_VIRT) && (UBASE_VIRT <= (KPOOL_VIRT + KPOOL_SIZE)))
+#if ((UBASE_VIRT >= KPOOL_VIRT) && (UBASE_VIRT < (KPOOL_VIRT + KPOOL_SIZE)))
 	#error "user address space overlaps with kernel page pool"
 #elif (((UBASE_VIRT + UMEM_SIZE) >= KPOOL_VIRT) && ((UBASE_VIRT + UMEM_SIZE) < (KPOOL_VIRT + KPOOL_SIZE)))
 	#error "user address space overlaps with kernel page pool"


### PR DESCRIPTION
In this commit, I fix the build checking in the Kernel Page Pool address. The
user space area should end **before** the Kernel Page Pool starts.