### PR TITLE
Bug Fix: Avoid Linking LibGCC with the Kernel

### DIFF
--- a/src/kernel/klib/kvsprintf.c
+++ b/src/kernel/klib/kvsprintf.c
@@ -54,11 +54,11 @@ PRIVATE int itoa(char *str, unsigned num, int base)
 	/* Convert number. */
 	do
 	{
-		int remainder = num % divisor;
+		unsigned remainder = num & 0xf;
 
 		*p++ = (remainder < 10) ? remainder + '0' : 
 		                          remainder + 'a' - 10;
-	} while (num /= divisor);
+	} while ((num = (num >> 4)));
 
 	/* Fill up with zeros. */
 	if (divisor == 16)
@@ -110,7 +110,7 @@ PUBLIC int kvsprintf(char *str, const char *fmt, va_list args)
 				/* Number. */
 				case 'd':
 				case 'x':
-					str += itoa(str, va_arg(args, unsigned int), *fmt);
+					str += itoa(str, va_arg(args, unsigned int), 'x');
 					break;
 				
 				/* String. */


### PR DESCRIPTION
In this commit, I introduce a workaround in the kvsprintf() function in
order to avoid the linkage of LibGCC routines to compute integer
divisions. Machine code of these functions seems to be buggy in the k1b
architecture, causing invalid opcode exceptions to arise in kernel land.

While these workaround does remove the decimal formatted print output
from the kernel, it is important to note that we do not **really** need
rich output in kernel land.