### PR TITLE
[k1b] Enhancement: Build for IO Clusters

### DIFF
--- a/build/makefile.i386-pc
+++ b/build/makefile.i386-pc
@@ -22,26 +22,52 @@
 # SOFTWARE.
 #
 
-# Kalray's Toolchain Directory
-export TOOLCHAIN_DIR=$(TOOLSDIR)/dev/toolchain/i386/bin/
-
+#===============================================================================
 # Target Configuration
+#===============================================================================
+
 export ARCH = i386
+
+#===============================================================================
+# Toolchain Configuration
+#===============================================================================
+
+# Toolchain Directory
+export TOOLCHAIN_DIR=$(TOOLSDIR)/dev/toolchain/i386/bin/
 
 # Toolchain
 export CC = $(TOOLCHAIN_DIR)/i386-elf-gcc
 export LD = $(TOOLCHAIN_DIR)/i386-elf-ld
 export AR = $(TOOLCHAIN_DIR)/i386-elf-ar
 
-# Toolchain configuration.
+# Compiler Options
 export CFLAGS   = -D __i386__ -D __pc__
 export CFLAGS  += -pedantic-errors -fextended-identifiers
 export CFLAGS  += -nostdlib -nostdinc -fno-stack-protector
 export CFLAGS  += -ansi -pedantic-errors
 export CFLAGS  += -Wstack-usage=4096
+
+# Linker Options
 export LDFLAGS  =
+
+#===============================================================================
+# Libraries and Binaries
+#===============================================================================
 
 # Libraries
 export LIBKERNEL = libkernel-$(ARCH).a
 export LIBNANVIX = libnanvix-$(ARCH).a
 export LIBS += $(LIBDIR)/$(LIBNANVIX) $(LIBDIR)/$(LIBKERNEL)
+
+# Binaries
+export EXECBIN = test-driver-$(TARGET)
+
+#===============================================================================
+
+# Builds Nanvix for the i386 PC target.
+nanvix-target:
+	$(MAKE) -C $(SRCDIR) -f build/makefile.i386 all
+
+# Cleans everything for the i386 PC target.
+distclean-target:
+	$(MAKE) -C $(SRCDIR) -f build/makefile.i386 distclean

--- a/build/makefile.mppa256
+++ b/build/makefile.mppa256
@@ -22,28 +22,53 @@
 # SOFTWARE.
 #
 
-# Kalray's Toolchain Directory
-export K1_TOOLCHAIN_DIR=/usr/local/k1tools/
-
+#===============================================================================
 # Target Configuration
+#===============================================================================
+
 export SYSTEM = bare
 export ARCH   = k1b
 export BOARD  = developer
-export CLUSTER = node
 
-# Toolchain
+#===============================================================================
+# Toolchain Configuration
+#===============================================================================
+
+# Toolchain Directory
+export K1_TOOLCHAIN_DIR=/usr/local/k1tools
+
+# Tools
 export CC = $(K1_TOOLCHAIN_DIR)/bin/k1-gcc
 export LD = $(K1_TOOLCHAIN_DIR)/bin/k1-gcc
 export AR = $(K1_TOOLCHAIN_DIR)/bin/k1-ar
 
-# Toolchain Configuration
+# Compiler Options
 export CFLAGS   = -D __mppa256__ -D __k1b__
-export CFLAGS  += -mos=$(SYSTEM) -mcluster=$(CLUSTER) -march=$(ARCH) -mboard=$(BOARD)
-export LDFLAGS  = -Tlink.ld
+export CFLAGS  += -mos=$(SYSTEM) -march=$(ARCH) -mboard=$(BOARD)
 
-# Libraries
-export LIBKERNEL    = libkernel-$(ARCH).a
-export LIBNANVIX    = libnanvix-$(ARCH).a
-export LIBS_OURS    = $(LIBDIR)/$(LIBNANVIX) $(LIBDIR)/$(LIBKERNEL)
-export LIBS_THEIRS  = -lvbsp -mhypervisor
-export LIBS        += $(LIBS_OURS) $(LIBS_THEIRS)
+# Linker Options
+export LDFLAGS  = -Tlink.ld -Wl,--allow-multiple-definition
+
+#===============================================================================
+
+# Builds Nanvix for the MPPA-256 target.
+nanvix-target: nanvix-k1bdp nanvix-k1bio
+
+# Cleans everything for the MPPA-256 target.
+distclean-target: distclean-k1bdp distclean-k1bio
+
+# Builds Nanvix for a Compute Cluster.
+nanvix-k1bdp:
+	$(MAKE) -C $(SRCDIR) -f build/makefile.k1bdp all
+
+# Builds Nanvix for an IO Cluster.
+nanvix-k1bio:
+	$(MAKE) -C $(SRCDIR) -f build/makefile.k1bio all
+
+# Cleans compilation files for a Compute Cluster.
+distclean-k1bdp:
+	$(MAKE) -C $(SRCDIR) -f build/makefile.k1bdp distclean
+
+# Cleans compilation files for an IO Cluster.
+distclean-k1bio:
+	$(MAKE) -C $(SRCDIR) -f build/makefile.k1bio distclean

--- a/include/target/kalray/mppa256.h
+++ b/include/target/kalray/mppa256.h
@@ -138,7 +138,7 @@
 		#define MPPA256_KPOOL_BASE_PHYS      0x00070000 /**< Kernel Pool Base     */
 		#define MPPA256_KPOOL_END_PHYS       0x00080000 /**< Kernel Pool End      */
 		#define MPPA256_USER_BASE_PHYS       0x00080000 /**< User Base            */
-		#define MPPA256_USER_END_PHYS        0x001f0000 /**< End End              */
+		#define MPPA256_USER_END_PHYS        0x001f0000 /**< User End             */
 		#define MPPA256_HYPER_HIGH_BASE_PHYS 0x001f0000 /**< High Hypervisor Base */
 	#elif defined(__node__)
 		#define MPPA256_HYPER_LOW_BASE_PHYS  0x00000000 /**< Low Hypervisor Base  */
@@ -148,7 +148,7 @@
 		#define MPPA256_KPOOL_BASE_PHYS      0x00058000 /**< Kernel Pool Base     */
 		#define MPPA256_KPOOL_END_PHYS       0x00078000 /**< Kernel Pool End      */
 		#define MPPA256_USER_BASE_PHYS       0x00078000 /**< User Base            */
-		#define MPPA256_USER_END_PHYS        0x001f8000 /**< End End.             */
+		#define MPPA256_USER_END_PHYS        0x001f8000 /**< User End.            */
 		#define MPPA256_HYPER_HIGH_BASE_PHYS 0x001f8000 /**< High Hypervisor Base */
 	#endif
 	/**@}*/

--- a/makefile
+++ b/makefile
@@ -22,11 +22,6 @@
 # SOFTWARE.
 #
 
-#
-# Release version.
-#
-VERSION=v0.1-beta.1
-
 #===============================================================================
 # Directories
 #===============================================================================
@@ -42,35 +37,23 @@ export TOOLSDIR = $(CURDIR)/tools
 
 #===============================================================================
 
-include $(MAKEDIR)/makefile.$(TARGET)
-
 # Image Name
 export IMAGE = nanvix-debug.img
 
 # Builds everything.
 all: image
 
-# Builds a release.
-release: image
-	tar -cjvf nanvix-$(VERSION).tar.bz2 \
-		build/makefile.mppa256          \
-		include                         \
-		lib                             \
-		scripts/arch/mppa256.sh
-
 # Builds image.
-image: nanvix
+image: | nanvix nanvix-target
 	bash $(TOOLSDIR)/image/build-image.sh $(BINDIR) $(IMAGE)
 
-# Builds binaries and libraries.
+# Builds Nanvix.
 nanvix:
 	mkdir -p $(BINDIR)
 	mkdir -p $(LIBDIR)
-	$(MAKE) -C $(SRCDIR) all
 
 # Cleans everything.
-distclean:
-	$(MAKE) -C $(SRCDIR) distclean
+distclean: distclean-target
 	rm -rf $(IMAGE)
 	rm -rf $(BINDIR) $(LIBDIR)
 
@@ -79,3 +62,4 @@ documentation:
 	mkdir -p $(DOCDIR)
 	doxygen doxygen/doxygen.$(TARGET)
 
+include $(MAKEDIR)/makefile.$(TARGET)

--- a/src/build/makefile.i386
+++ b/src/build/makefile.i386
@@ -22,20 +22,4 @@
 # SOFTWARE.
 #
 
-export K1_TOOLCHAIN_DIR="/usr/local/k1tools"
-
-#
-# Builds a multi-binary file.
-#
-function build
-{
-	local bindir=$1
-	local iobin=$2
-	local nodebin=$3
-	local multibin=$4
-
-	$K1_TOOLCHAIN_DIR/bin/k1-create-multibinary \
-		--boot $bindir/$iobin                   \
-		--clusters $bindir/$nodebin             \
-		-T $multibin
-}
+include $(SRCDIR)/build/makefile.nanvix

--- a/src/build/makefile.k1bdp
+++ b/src/build/makefile.k1bdp
@@ -33,6 +33,7 @@ export CLUSTER = node
 # Toolchain Configuration
 #===============================================================================
 
+# Compiler Options
 export CFLAGS += -mcluster=$(CLUSTER)
 
 #===============================================================================
@@ -44,7 +45,6 @@ export LIBKERNEL    = libkernel-$(ARCH)-$(CLUSTER).a
 export LIBNANVIX    = libnanvix-$(ARCH)-$(CLUSTER).a
 export LIBS_OURS    = $(LIBDIR)/$(LIBNANVIX) $(LIBDIR)/$(LIBKERNEL)
 export LIBS_THEIRS  = -lvbsp -mhypervisor
-export LIBS        += $(LIBS_OURS) $(LIBS_THEIRS)
 
 # Binaries
 export EXECBIN = test-driver-k1bdp

--- a/src/build/makefile.k1bdp
+++ b/src/build/makefile.k1bdp
@@ -23,56 +23,30 @@
 #
 
 #===============================================================================
+# Target Configuration
+#===============================================================================
+
+# Target Configuration
+export CLUSTER = node
+
+#===============================================================================
 # Toolchain Configuration
 #===============================================================================
 
-# Compiler Options.
-export CFLAGS  += -std=c99 -fno-builtin
-export CFLAGS  += -Wall -Wextra -Werror -Wa,--warn
-export CFLAGS  += -Winit-self -Wswitch-default -Wfloat-equal
-export CFLAGS  += -Wundef -Wshadow -Wuninitialized -Wlogical-op
-export CFLAGS  += -Wvla # -Wredundant-decls
-export CFLAGS  += -I $(INCDIR)
-ifeq ($(RELEASE), true)
-	export CFLAGS  += -O3 -D NDEBUG
-else
-	export CFLAGS  += -Og -g
-endif
-
-
-# Linker Options
-export LDFLAGS +=
-
-# Archiver Options
-export ARFLAGS = rc
+export CFLAGS += -mcluster=$(CLUSTER)
 
 #===============================================================================
-# Binaries and Libraries
+# Libraries and Binaries
 #===============================================================================
 
-export EXECBIN = test-driver
+# Libraries
+export LIBKERNEL    = libkernel-$(ARCH)-$(CLUSTER).a
+export LIBNANVIX    = libnanvix-$(ARCH)-$(CLUSTER).a
+export LIBS_OURS    = $(LIBDIR)/$(LIBNANVIX) $(LIBDIR)/$(LIBKERNEL)
+export LIBS_THEIRS  = -lvbsp -mhypervisor
+export LIBS        += $(LIBS_OURS) $(LIBS_THEIRS)
 
-#===============================================================================
+# Binaries
+export EXECBIN = test-driver-k1bdp
 
-# Conflicts
-.PHONY: kernel
-.PHONY: libs
-.PHONY: test
-
-# Builds everything.
-all: kernel libs
-	$(MAKE) -C test $(TARGET)
-
-# Builds the kernel.
-kernel: 
-	$(MAKE) -C kernel all
-
-# Builds system libraries.
-libs:
-	$(MAKE) -C libs all
-
-# Cleans compilation files.
-distclean:
-	$(MAKE) -C kernel clean
-	$(MAKE) -C libs clean
-	$(MAKE) -C test clean
+include $(SRCDIR)/build/makefile.nanvix

--- a/src/build/makefile.k1bio
+++ b/src/build/makefile.k1bio
@@ -33,6 +33,7 @@ export CLUSTER = ioddr
 # Toolchain Configuration
 #===============================================================================
 
+# Compiler Options
 export CFLAGS += -mcluster=$(CLUSTER)
 
 #===============================================================================
@@ -44,7 +45,6 @@ export LIBKERNEL    = libkernel-$(ARCH)-$(CLUSTER).a
 export LIBNANVIX    = libnanvix-$(ARCH)-$(CLUSTER).a
 export LIBS_OURS    = $(LIBDIR)/$(LIBNANVIX) $(LIBDIR)/$(LIBKERNEL)
 export LIBS_THEIRS  = -lvbsp -mhypervisor
-export LIBS        += $(LIBS_OURS) $(LIBS_THEIRS)
 
 # Binaries
 export EXECBIN = test-driver-k1bio

--- a/src/build/makefile.k1bio
+++ b/src/build/makefile.k1bio
@@ -22,45 +22,31 @@
 # SOFTWARE.
 #
 
-# C Source Files
-C_SRC = $(wildcard hal/arch/$(ARCH)/*.c) \
-        $(wildcard hal/*.c)              \
-        $(wildcard init/*.c)             \
-        $(wildcard klib/*.c)             \
-        $(wildcard dev/*.c)              \
-        $(wildcard dev/stdout/console.c) \
-        $(wildcard mm/*.c)
+#===============================================================================
+# Target Configuration
+#===============================================================================
 
-# Unit Tests for Kernel
-ifneq ($(RELEASE), true)
-C_SRC += $(wildcard test/*.c)
-endif
+# Target Configuration
+export CLUSTER = ioddr
 
-# Asembly Source Files
-ASM_SRC = $(wildcard hal/arch/$(ARCH)/*.S)
+#===============================================================================
+# Toolchain Configuration
+#===============================================================================
 
-# Object Files
-OBJ = $(ASM_SRC:.S=.o) \
-	  $(C_SRC:.c=.o)
+export CFLAGS += -mcluster=$(CLUSTER)
 
-# Executable file.
-EXEC = kernel
+#===============================================================================
+# Libraries and Binaries
+#===============================================================================
 
-# Linker Configuration
-export LDFLAGS = -T hal/arch/$(ARCH)/link.ld
+# Libraries
+export LIBKERNEL    = libkernel-$(ARCH)-$(CLUSTER).a
+export LIBNANVIX    = libnanvix-$(ARCH)-$(CLUSTER).a
+export LIBS_OURS    = $(LIBDIR)/$(LIBNANVIX) $(LIBDIR)/$(LIBKERNEL)
+export LIBS_THEIRS  = -lvbsp -mhypervisor
+export LIBS        += $(LIBS_OURS) $(LIBS_THEIRS)
 
-# Builds All Object Files
-all: $(OBJ)
-	$(LD) $(LDFLAGS) $(OBJ) -o $(BINDIR)/$(EXEC)
+# Binaries
+export EXECBIN = test-driver-k1bio
 
-# Cleans All Object Files
-clean:
-	rm -rf $(BINDIR)/$(EXEC) $(OBJ)
-
-# Builds a C Source file
-%.o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
-
-# Builds an ASM Source File
-%.o: %.S
-	$(CC) $(CFLAGS) $< -c -o $@
+include $(SRCDIR)/build/makefile.nanvix

--- a/src/build/makefile.nanvix
+++ b/src/build/makefile.nanvix
@@ -2,7 +2,6 @@
 # MIT License
 #
 # Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
-#              2018 Davidson Francis     <davidsondfgl@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,50 +23,58 @@
 #
 
 #===============================================================================
-# Target Configuration
-#===============================================================================
-
-# Target Configuration
-export ARCH = or1k
-
-#===============================================================================
 # Toolchain Configuration
 #===============================================================================
 
-# Toolchain Directory
-export TOOLCHAIN_DIR=$(TOOLSDIR)/dev/toolchain/or1k/bin/
+# Compiler Options.
+export CFLAGS  += -std=c99 -fno-builtin
+export CFLAGS  += -Wall -Wextra -Werror -Wa,--warn
+export CFLAGS  += -Winit-self -Wswitch-default -Wfloat-equal
+export CFLAGS  += -Wundef -Wshadow -Wuninitialized -Wlogical-op
+export CFLAGS  += -Wvla # -Wredundant-decls
+export CFLAGS  += -I $(INCDIR)
+ifeq ($(RELEASE), true)
+	export CFLAGS  += -O3 -D NDEBUG
+else
+	export CFLAGS  += -Og -g
+endif
 
-# Toolchain
-export CC = $(TOOLCHAIN_DIR)/or1k-elf-gcc
-export LD = $(TOOLCHAIN_DIR)/or1k-elf-ld
-export AR = $(TOOLCHAIN_DIR)/or1k-elf-ar
-
-# Compiler Options
-export CFLAGS   = -D __or1k__ -D __pc__
-export CFLAGS  += -pedantic-errors -fextended-identifiers
-export CFLAGS  += -nostdlib -nostdinc -fno-stack-protector
-
-# Linker Options
-export LDFLAGS  =
-
-#===============================================================================
-# Libraries and Binaries
-#===============================================================================
-
-# Libraries
-export LIBKERNEL = libkernel-$(ARCH).a
-export LIBNANVIX = libnanvix-$(ARCH).a
-export LIBS += $(LIBDIR)/$(LIBNANVIX) $(LIBDIR)/$(LIBKERNEL)
-
-# Binaries
-export EXECBIN = test-driver-$(TARGET)
+# Archiver Options
+export ARFLAGS = rc
 
 #===============================================================================
 
-# Builds Nanvix for the or1k PC target.
-nanvix-target:
-	$(MAKE) -C $(SRCDIR) -f build/makefile.or1k all
+# Conflicts
+.PHONY: kernel
+.PHONY: libs
+.PHONY: test
 
-# Cleans everything for the or1k PC target.
-distclean-target:
-	$(MAKE) -C $(SRCDIR) -f build/makefile.or1k distclean
+# Builds everything.
+all: test
+
+# Cleans compilation files.
+distclean: distclean-kernel distclean-libs distclean-test
+
+# User-level testing units.
+test: kernel libs
+	$(MAKE) -C test
+
+# Builds system libraries.
+libs: kernel
+	$(MAKE) -C libs all
+
+# Builds the kernel.
+kernel:
+	$(MAKE) -C kernel all
+
+# Cleans kernel compilation files.
+distclean-kernel:
+	$(MAKE) -C kernel clean
+
+# Cleans system librarie compilation files.
+distclean-libs:
+	$(MAKE) -C libs clean
+
+# Cleans user-level testing units compilation files.
+distclean-test:
+	$(MAKE) -C test clean

--- a/src/build/makefile.or1k
+++ b/src/build/makefile.or1k
@@ -22,20 +22,4 @@
 # SOFTWARE.
 #
 
-export K1_TOOLCHAIN_DIR="/usr/local/k1tools"
-
-#
-# Builds a multi-binary file.
-#
-function build
-{
-	local bindir=$1
-	local iobin=$2
-	local nodebin=$3
-	local multibin=$4
-
-	$K1_TOOLCHAIN_DIR/bin/k1-create-multibinary \
-		--boot $bindir/$iobin                   \
-		--clusters $bindir/$nodebin             \
-		-T $multibin
-}
+include $(SRCDIR)/build/makefile.nanvix

--- a/src/kernel/build/makefile.i386-pc
+++ b/src/kernel/build/makefile.i386-pc
@@ -22,20 +22,31 @@
 # SOFTWARE.
 #
 
-export K1_TOOLCHAIN_DIR="/usr/local/k1tools"
+# C Source Files
+C_SRC += $(wildcard dev/stdout/console.c)
 
-#
-# Builds a multi-binary file.
-#
-function build
-{
-	local bindir=$1
-	local iobin=$2
-	local nodebin=$3
-	local multibin=$4
+# Object Files
+OBJ = $(ASM_SRC:.S=.o) \
+	  $(C_SRC:.c=.o)
 
-	$K1_TOOLCHAIN_DIR/bin/k1-create-multibinary \
-		--boot $bindir/$iobin                   \
-		--clusters $bindir/$nodebin             \
-		-T $multibin
-}
+# Executable file.
+EXEC = kernel
+
+# Linker Configuration
+export LDFLAGS = -T hal/arch/$(ARCH)/link.ld
+
+# Builds All Object Files
+all: $(OBJ)
+	$(LD) $(LDFLAGS) $(OBJ) -o $(BINDIR)/$(EXEC)
+
+# Cleans All Object Files
+clean:
+	rm -rf $(BINDIR)/$(EXEC) $(OBJ)
+
+# Builds a C Source file
+%.o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@
+
+# Builds an ASM Source File
+%.o: %.S
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/kernel/build/makefile.mppa256
+++ b/src/kernel/build/makefile.mppa256
@@ -23,15 +23,15 @@
 #
 
 # C Source Files
-C_SRC = $(wildcard hal/arch/$(ARCH)/*.c) \
-        $(wildcard hal/*.c)              \
-        $(wildcard init/*.c)             \
-        $(wildcard klib/*.c)             \
-        $(wildcard dev/*.c)              \
-        $(wildcard mm/*.c)               \
-        $(wildcard dev/stdout/jtag.c)    \
-        $(wildcard pm/*.c)               \
-        $(wildcard sys/*.c)
+C_SRC += $(wildcard hal/arch/$(ARCH)/*.c) \
+         $(wildcard hal/*.c)              \
+         $(wildcard init/*.c)             \
+         $(wildcard klib/*.c)             \
+         $(wildcard dev/*.c)              \
+         $(wildcard mm/*.c)               \
+         $(wildcard dev/stdout/jtag.c)    \
+         $(wildcard pm/*.c)               \
+         $(wildcard sys/*.c)
 
 # Unit Tests for Kernel
 ifneq ($(RELEASE), true)

--- a/src/kernel/build/makefile.mppa256
+++ b/src/kernel/build/makefile.mppa256
@@ -22,20 +22,40 @@
 # SOFTWARE.
 #
 
-export K1_TOOLCHAIN_DIR="/usr/local/k1tools"
+# C Source Files
+C_SRC = $(wildcard hal/arch/$(ARCH)/*.c) \
+        $(wildcard hal/*.c)              \
+        $(wildcard init/*.c)             \
+        $(wildcard klib/*.c)             \
+        $(wildcard dev/*.c)              \
+        $(wildcard mm/*.c)               \
+        $(wildcard dev/stdout/jtag.c)    \
+        $(wildcard pm/*.c)               \
+        $(wildcard sys/*.c)
 
-#
-# Builds a multi-binary file.
-#
-function build
-{
-	local bindir=$1
-	local iobin=$2
-	local nodebin=$3
-	local multibin=$4
+# Unit Tests for Kernel
+ifneq ($(RELEASE), true)
+C_SRC += $(wildcard test/*.c) \
+         $(wildcard test/hal/hal.c) \
+         $(wildcard test/hal/core/*.c)
+endif
 
-	$K1_TOOLCHAIN_DIR/bin/k1-create-multibinary \
-		--boot $bindir/$iobin                   \
-		--clusters $bindir/$nodebin             \
-		-T $multibin
-}
+# Object Files
+OBJ = $(ASM_SRC:.S=.$(CLUSTER).o) \
+	  $(C_SRC:.c=.$(CLUSTER).o)
+
+# Builds All Object Files
+all: $(OBJ)
+	$(AR) $(ARFLAGS) $(LIBDIR)/$(LIBKERNEL) $(OBJ)
+
+# Cleans All Object Files
+clean:
+	rm -rf $(LIBDIR)/$(LIBKERNEL) $(OBJ)
+
+# Builds a C Source file
+%.$(CLUSTER).o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@
+
+# Builds an ASM Source File
+%.$(CLUSTER).o: %.S
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/kernel/build/makefile.or1k-pc
+++ b/src/kernel/build/makefile.or1k-pc
@@ -2,6 +2,7 @@
 # MIT License
 #
 # Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#              2018 Davidson Francis     <davidsondfgl@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,20 +23,35 @@
 # SOFTWARE.
 #
 
-export K1_TOOLCHAIN_DIR="/usr/local/k1tools"
+# Unit Tests for Kernel
+ifneq ($(RELEASE), true)
+C_SRC += $(wildcard test/*.c) \
+         $(wildcard test/hal/hal.c) \
+         $(wildcard test/hal/core/*.c)
+endif
 
-#
-# Builds a multi-binary file.
-#
-function build
-{
-	local bindir=$1
-	local iobin=$2
-	local nodebin=$3
-	local multibin=$4
+# Object Files
+OBJ = $(ASM_SRC:.S=.o) \
+	  $(C_SRC:.c=.o)
 
-	$K1_TOOLCHAIN_DIR/bin/k1-create-multibinary \
-		--boot $bindir/$iobin                   \
-		--clusters $bindir/$nodebin             \
-		-T $multibin
-}
+# Executable file.
+EXEC = kernel
+
+# Linker Configuration
+export LDFLAGS = -T hal/arch/$(ARCH)/link.ld
+
+# Builds All Object Files
+all: $(OBJ)
+	$(LD) $(LDFLAGS) $(OBJ) -o $(BINDIR)/$(EXEC)
+
+# Cleans All Object Files
+clean:
+	rm -rf $(BINDIR)/$(EXEC) $(OBJ)
+
+# Builds a C Source file
+%.o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@
+
+# Builds an ASM Source File
+%.o: %.S
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/kernel/makefile
+++ b/src/kernel/makefile
@@ -22,4 +22,15 @@
 # SOFTWARE.
 #
 
-include makefile.$(TARGET)
+# C Source Files
+C_SRC = $(wildcard hal/arch/$(ARCH)/*.c) \
+        $(wildcard hal/*.c)              \
+        $(wildcard init/*.c)             \
+        $(wildcard klib/*.c)             \
+        $(wildcard dev/*.c)              \
+        $(wildcard mm/*.c)
+
+# Asembly Source Files
+ASM_SRC = $(wildcard hal/arch/$(ARCH)/*.S)
+
+include build/makefile.$(TARGET)

--- a/src/libs/build/makefile.i386-pc
+++ b/src/libs/build/makefile.i386-pc
@@ -22,20 +22,17 @@
 # SOFTWARE.
 #
 
-export K1_TOOLCHAIN_DIR="/usr/local/k1tools"
+# Object Files
+OBJ = $(SRC:.c=..o)
 
-#
-# Builds a multi-binary file.
-#
-function build
-{
-	local bindir=$1
-	local iobin=$2
-	local nodebin=$3
-	local multibin=$4
+# Builds All Object Files
+all: $(OBJ)
+	$(AR) $(ARFLAGS) $(LIBDIR)/$(LIBNANVIX) $(OBJ)
 
-	$K1_TOOLCHAIN_DIR/bin/k1-create-multibinary \
-		--boot $bindir/$iobin                   \
-		--clusters $bindir/$nodebin             \
-		-T $multibin
-}
+# Cleans All Object Files
+clean:
+	rm -rf $(LIBDIR)/$(LIBNANVIX) $(OBJ)
+
+# Builds a C Source file
+%.o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/libs/build/makefile.mppa256
+++ b/src/libs/build/makefile.mppa256
@@ -22,20 +22,17 @@
 # SOFTWARE.
 #
 
-export K1_TOOLCHAIN_DIR="/usr/local/k1tools"
+# Object Files
+OBJ = $(SRC:.c=.$(CLUSTER).o)
 
-#
-# Builds a multi-binary file.
-#
-function build
-{
-	local bindir=$1
-	local iobin=$2
-	local nodebin=$3
-	local multibin=$4
+# Builds All Object Files
+all: $(OBJ)
+	$(AR) $(ARFLAGS) $(LIBDIR)/$(LIBNANVIX) $(OBJ)
 
-	$K1_TOOLCHAIN_DIR/bin/k1-create-multibinary \
-		--boot $bindir/$iobin                   \
-		--clusters $bindir/$nodebin             \
-		-T $multibin
-}
+# Cleans All Object Files
+clean:
+	rm -rf $(LIBDIR)/$(LIBNANVIX) $(OBJ)
+
+# Builds a C Source file
+%.$(CLUSTER).o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/libs/build/makefile.or1k-pc
+++ b/src/libs/build/makefile.or1k-pc
@@ -22,20 +22,17 @@
 # SOFTWARE.
 #
 
-export K1_TOOLCHAIN_DIR="/usr/local/k1tools"
+# Object Files
+OBJ = $(SRC:.c=..o)
 
-#
-# Builds a multi-binary file.
-#
-function build
-{
-	local bindir=$1
-	local iobin=$2
-	local nodebin=$3
-	local multibin=$4
+# Builds All Object Files
+all: $(OBJ)
+	$(AR) $(ARFLAGS) $(LIBDIR)/$(LIBNANVIX) $(OBJ)
 
-	$K1_TOOLCHAIN_DIR/bin/k1-create-multibinary \
-		--boot $bindir/$iobin                   \
-		--clusters $bindir/$nodebin             \
-		-T $multibin
-}
+# Cleans All Object Files
+clean:
+	rm -rf $(LIBDIR)/$(LIBNANVIX) $(OBJ)
+
+# Builds a C Source file
+%.o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/libs/makefile
+++ b/src/libs/makefile
@@ -25,17 +25,4 @@
 # Source Files
 SRC = $(wildcard nanvix/$(ARCH)/*.c)
 
-# Object Files
-OBJ = $(SRC:.c=.o)
-
-# Builds All Object Files
-all: $(OBJ)
-	$(AR) $(ARFLAGS) $(LIBDIR)/$(LIBNANVIX) $(OBJ)
-
-# Cleans All Object Files
-clean:
-	rm -rf $(LIBDIR)/$(LIBNANVIX) $(OBJ)
-
-# Builds a C Source file
-%.o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+include build/makefile.$(TARGET)

--- a/src/test/build/makefile.i386-pc
+++ b/src/test/build/makefile.i386-pc
@@ -2,7 +2,6 @@
 # MIT License
 #
 # Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
-#              2018 Davidson Francis     <davidsondfgl@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,46 +22,13 @@
 # SOFTWARE.
 #
 
-# C Source Files
-C_SRC = $(wildcard hal/arch/$(ARCH)/*.c) \
-        $(wildcard hal/*.c)              \
-        $(wildcard init/*.c)             \
-        $(wildcard klib/*.c)             \
-        $(wildcard dev/*.c)              \
-        $(wildcard mm/*.c)
-
-# Unit Tests for Kernel
-ifneq ($(RELEASE), true)
-C_SRC += $(wildcard test/*.c) \
-         $(wildcard test/hal/hal.c) \
-         $(wildcard test/hal/core/*.c)
-endif
-
-# Asembly Source Files
-ASM_SRC = $(wildcard hal/arch/$(ARCH)/*.S)
-
 # Object Files
-OBJ = $(ASM_SRC:.S=.o) \
-	  $(C_SRC:.c=.o)
+OBJ = $(SRC:.c=.o)
 
-# Executable file.
-EXEC = kernel
+# Builds object files for i386 PC target.
+all:
+	# Nothing to do.
 
-# Linker Configuration
-export LDFLAGS = -T hal/arch/$(ARCH)/link.ld
-
-# Builds All Object Files
-all: $(OBJ)
-	$(LD) $(LDFLAGS) $(OBJ) -o $(BINDIR)/$(EXEC)
-
-# Cleans All Object Files
+# Cleans all object files.
 clean:
-	rm -rf $(BINDIR)/$(EXEC) $(OBJ)
-
-# Builds a C Source file
-%.o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
-
-# Builds an ASM Source File
-%.o: %.S
-	$(CC) $(CFLAGS) $< -c -o $@
+	rm -rf $(BINDIR)/$(EXECBIN) $(OBJ)

--- a/src/test/build/makefile.mppa256
+++ b/src/test/build/makefile.mppa256
@@ -27,7 +27,7 @@ OBJ = $(SRC:.c=.$(CLUSTER).o)
 
 # Builds object files for MPPA-256 target.
 mppa256: $(OBJ)
-	$(CC) $(CFLAGS) $(LDFLAGS) $(SRC) -o $(BINDIR)/$(EXECBIN) -Wl,--whole-archive $(LIBS_OURS) -Wl,--no-whole-archive $(LIBS_THEIRS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJ) -o $(BINDIR)/$(EXECBIN) -Wl,--whole-archive $(LIBS_OURS) -Wl,--no-whole-archive $(LIBS_THEIRS)
 
 # Cleans all object files.
 clean:

--- a/src/test/build/makefile.mppa256
+++ b/src/test/build/makefile.mppa256
@@ -22,20 +22,17 @@
 # SOFTWARE.
 #
 
-export K1_TOOLCHAIN_DIR="/usr/local/k1tools"
+# Object Files
+OBJ = $(SRC:.c=.$(CLUSTER).o)
 
-#
-# Builds a multi-binary file.
-#
-function build
-{
-	local bindir=$1
-	local iobin=$2
-	local nodebin=$3
-	local multibin=$4
+# Builds object files for MPPA-256 target.
+mppa256: $(OBJ)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(SRC) -o $(BINDIR)/$(EXECBIN) -Wl,--whole-archive $(LIBS_OURS) -Wl,--no-whole-archive $(LIBS_THEIRS)
 
-	$K1_TOOLCHAIN_DIR/bin/k1-create-multibinary \
-		--boot $bindir/$iobin                   \
-		--clusters $bindir/$nodebin             \
-		-T $multibin
-}
+# Cleans all object files.
+clean:
+	rm -rf $(BINDIR)/$(EXECBIN) $(OBJ)
+
+# Builds a C source file.
+%.$(CLUSTER).o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/test/build/makefile.or1k-pc
+++ b/src/test/build/makefile.or1k-pc
@@ -22,45 +22,13 @@
 # SOFTWARE.
 #
 
-# C Source Files
-C_SRC = $(wildcard *.c)                  \
-        $(wildcard hal/arch/$(ARCH)/*.c) \
-        $(wildcard hal/*.c)              \
-        $(wildcard dev/jtag.c)           \
-        $(wildcard dev/*.c)              \
-        $(wildcard dev/stdout/jtag.c)    \
-        $(wildcard init/*.c)             \
-        $(wildcard klib/*.c)             \
-        $(wildcard mm/*.c)               \
-        $(wildcard pm/*.c)               \
-        $(wildcard sys/*.c)
-
-# Unit Tests for Kernel
-ifneq ($(RELEASE), true)
-C_SRC += $(wildcard test/*.c) \
-         $(wildcard test/hal/hal.c) \
-         $(wildcard test/hal/core/*.c)
-endif
-
-# Asembly Source Files
-ASM_SRC = $(wildcard hal/arch/$(ARCH)/*.S)
-
 # Object Files
-OBJ = $(ASM_SRC:.S=.o) \
-	  $(C_SRC:.c=.o)
+OBJ = $(SRC:.c=.o)
 
-# Builds All Object Files
-all: $(OBJ)
-	$(AR) $(ARFLAGS) $(LIBDIR)/$(LIBKERNEL) $(OBJ)
+# Builds object files for or1k PC target.
+all:
+	# Nothing to do.
 
-# Cleans All Object Files
+# Cleans all object files.
 clean:
-	rm -rf $(LIBDIR)/$(LIBKERNEL) $(OBJ)
-
-# Builds a C Source file
-%.o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
-
-# Builds an ASM Source File
-%.o: %.S
-	$(CC) $(CFLAGS) $< -c -o $@
+	rm -rf $(BINDIR)/$(EXECBIN) $(OBJ)

--- a/src/test/makefile
+++ b/src/test/makefile
@@ -25,25 +25,4 @@
 # Source Files
 SRC = $(wildcard *.c)
 
-# Object Files
-OBJ = $(SRC:.c=.o)
-
-# Builds object files for MPPA-256 target.
-mppa256: $(OBJ)
-	$(CC) $(CFLAGS) $(LDFLAGS) $(SRC) -o $(BINDIR)/$(EXECBIN) -Wl,--whole-archive $(LIBS_OURS) -Wl,--no-whole-archive $(LIBS_THEIRS)
-
-# Builds object files for i386 target.
-i386-pc:
-	# Nothing to do.
-
-# Builds object files for or1k target.
-or1k-pc:
-	# Nothing to do.
-
-# Cleans all object files.
-clean:
-	rm -rf $(BINDIR)/$(EXECBIN) $(OBJ)
-
-# Builds a C source file.
-%.o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+include build/makefile.$(TARGET)

--- a/tools/image/build-image.sh
+++ b/tools/image/build-image.sh
@@ -22,6 +22,7 @@
 
 BINDIR=$1
 IMAGE=$2
+BIN="test-driver"
 
 #
 # Missing target argument.
@@ -42,14 +43,17 @@ fi
 
 # Parse target.
 case "$TARGET" in
-	"mppa256" )
+	"mppa256")
 		source "tools/image/arch/mppa256.sh"
+		BIN="$BIN-k1bio $BIN-k1bdp"
 		;;
 	"i386-pc")
 		source "tools/image/arch/i386.sh"
+		BIN="$BIN-i386"
 		;;
 	"or1k-pc")
 		source "tools/image/arch/or1k.sh"
+		BIN="$BIN-or1k"
 		;;
 	*)
         echo "error: unsupported target"
@@ -58,4 +62,4 @@ case "$TARGET" in
 esac
 
 # Build multi-binaries.
-build $BINDIR test-driver $IMAGE
+build $BINDIR $BIN $IMAGE

--- a/tools/run/arch/mppa256.sh
+++ b/tools/run/arch/mppa256.sh
@@ -35,18 +35,37 @@ function run_hw
 	local bin=$2
 	local args=$3
 	local debug=$4
+	local type=$5
+	local execfile=""
+
+	case $type in
+		"--all")
+			execfile="--exec-file=IODDR0:$bin-k1bio   \
+				  --exec-file=Cluster0:$bin-k1bdp"
+			;;
+		"--iocluster")
+			execfile="--exec-file=IODDR0:$bin-k1bio"
+			;;
+		"--ccluster")
+			execfile="--exec-file=Cluster0:$bin-k1bdp"
+			;;
+		*)
+			echo "error: type not specified [--all | --iocluster | --ccluster]"
+			exit 1
+			;;
+	esac
 
 	if [ $debug == "--no-debug" ];
 	then
 		$K1_TOOLCHAIN_DIR/bin/k1-jtag-runner \
 			--multibinary=$multibin          \
-			--exec-file=Cluster0:$bin        \
+			$execfile                        \
 			-- $args
 	else
 		$K1_TOOLCHAIN_DIR/bin/k1-jtag-runner \
 			--gdb                            \
 			--multibinary=$multibin          \
-			--exec-file=Cluster0:$bin        \
+			$execfile                        \
 			-- $args
 	fi
 }

--- a/tools/run/run.sh
+++ b/tools/run/run.sh
@@ -26,6 +26,7 @@
 test=$1  # Target test.
 mode=$2  # Test mode.
 debug=$3 # Launch GDB?
+type=$4  # Target type.
 
 if [ -z $TARGET ]; then
 	echo "$0: missing target architecture"
@@ -64,6 +65,14 @@ then
 fi
 
 #
+# All Types.
+#
+if [ -z $type ];
+then
+	type="--all"
+fi
+
+#
 # Stops regression test if running running short test.
 #
 function stop_if_short_test
@@ -80,7 +89,7 @@ case $test in
 	;&
 	kernel-core)
 		echo "=== Running Core and NoC Interface Tests"
-		run_hw "nanvix-debug.img" "bin/test-driver" "--debug --hal-core" "$debug"
+		run_hw "nanvix-debug.img" "bin/test-driver" "--debug --hal-core" "$debug" "$type"
 		stop_if_short_test $mode
 	;&
 esac


### PR DESCRIPTION
In this commit, I have severely changed the building system, so as to
support building for IO clusters in the MPPA-256 target. Furthermore, I
have stripped down target-dependent rules, so that it becomes easier to
adapt the source tree to new targets.