### PR TITLE
Bugfix bad idle pgdir

### DIFF
--- a/include/nanvix/mm.h
+++ b/include/nanvix/mm.h
@@ -501,7 +501,7 @@
 	 *
 	 * @todo This shall be moved to the Hardware Abstraction Layer (HAL).
 	 */
-	EXTERN struct pde idle_pgdir[];
+	EXTERN struct pde *idle_pgdir;
 
 /**@}*/
 

--- a/src/kernel/hal/arch/k1b/mmu.c
+++ b/src/kernel/hal/arch/k1b/mmu.c
@@ -249,7 +249,7 @@ PUBLIC void k1b_mmu_setup(void)
 
 		/* Build root page directory. */
 		root_pgdir[0].present = 1;
-		root_pgdir[0].present = 1;
+		root_pgdir[0].writable = 1;
 		root_pgdir[0].user = 0;
 		root_pgdir[0].frame = (vaddr_t)(root_pgtab) >> K1B_PAGE_SHIFT;
 	}

--- a/src/kernel/hal/arch/k1b/mmu.c
+++ b/src/kernel/hal/arch/k1b/mmu.c
@@ -67,7 +67,10 @@ PUBLIC struct pte root_pgtab[K1B_PGTAB_LENGTH];
  */
 PUBLIC struct pde root_pgdir[K1B_PGDIR_LENGTH];
 
-PUBLIC struct pde *idle_pgdir = root_pgdir;
+/**
+ * Alias to root page directory.
+ */
+PUBLIC struct pde *idle_pgdir = &root_pgdir[0];
 
 /**
  * @brief Map Hypervisor page frames.

--- a/src/kernel/hal/arch/k1b/mmu.c
+++ b/src/kernel/hal/arch/k1b/mmu.c
@@ -65,7 +65,7 @@ PUBLIC struct pte root_pgtab[K1B_PGTAB_LENGTH];
 /**
  * @brief Root Page Directories.
  */
-PUBLIC struct pde root_pgdir[K1B_PGDIR_LENGTH];
+PRIVATE struct pde root_pgdir[K1B_PGDIR_LENGTH];
 
 /**
  * Alias to root page directory.


### PR DESCRIPTION
Previously, idle_pgdir was declared as an array, though it should be a
a pointer to the root page directory. This bug was causing bad page walk
in the k1b architecture, and thus it got fixed.
