### PR TITLE
[k1b] Bug Fix: Misaligned Root Page Table

### DIFF
--- a/src/kernel/hal/arch/k1b/mmu.c
+++ b/src/kernel/hal/arch/k1b/mmu.c
@@ -60,12 +60,12 @@
 /**
  * @brief Root Page Table.
  */
-PUBLIC struct pte root_pgtab[K1B_PGTAB_LENGTH];
+PRIVATE struct pte root_pgtab[K1B_PGTAB_LENGTH] __attribute__((aligned(K1B_PAGE_SIZE)));
 
 /**
  * @brief Root Page Directories.
  */
-PRIVATE struct pde root_pgdir[K1B_PGDIR_LENGTH];
+PRIVATE struct pde root_pgdir[K1B_PGDIR_LENGTH] __attribute__((aligned(K1B_PAGE_SIZE)));
 
 /**
  * Alias to root page directory.


### PR DESCRIPTION
Previously, the root page table and page table directories were not
properly aligned at a page boundary, thus causing the page table
structures to be incorrectly filled up. In this commit, I have fixed
this problem by ensuring that these table are properly aligned when
building the binary file.