### PR TITLE
Bugfix k1b context

### DIFF
--- a/include/arch/k1b/context.h
+++ b/include/arch/k1b/context.h
@@ -196,7 +196,13 @@
 		;;
 		sd K1B_CONTEXT_R10[$r12], $p10 /**< r10 + r11 */
 		;;
-		sd K1B_CONTEXT_R12[$r12], $p12 /**< r12 + r13 */
+		copy $r1 = $r13
+		;;
+		copy $r0 = $r12
+		;;
+		add $r0, $r0, K1B_CONTEXT_SIZE
+		;;
+		sd K1B_CONTEXT_R12[$r12], $p0  /**< r12 + r13 */
 		;;
 		sd K1B_CONTEXT_R14[$r12], $p14 /**< r14 + r15 */
 		;;
@@ -312,7 +318,7 @@
 		set   $le = $r4
 		;;
 
-		/* Save GPRs. */
+		/* Restore GPRs. */
 		ld $p0  = K1B_CONTEXT_R0[$r12]  /**< r0  + r1  */
 		;;
 		ld $p2  = K1B_CONTEXT_R2[$r12]  /**< r2  + r3  */
@@ -325,7 +331,7 @@
 		;;
 		ld $p10 = K1B_CONTEXT_R10[$r12] /**< r10 + r11 */
 		;;
-		ld $p12 = K1B_CONTEXT_R12[$r12] /**< r12 + r13 */
+		lw $r13 = K1B_CONTEXT_R13[$r12] /**< r13       */
 		;;
 		ld $p14 = K1B_CONTEXT_R14[$r12] /**< r14 + r15 */
 		;;

--- a/src/kernel/hal/arch/k1b/hooks.S
+++ b/src/kernel/hal/arch/k1b/hooks.S
@@ -225,9 +225,9 @@ _do_excp:
 	_scoreboard_get $r2 $r3
 
 	/* Restore saved program counter. */
-	ld  $p4 = K1B_CONTEXT_SPC[$sp]
+	lw  $r4 = K1B_CONTEXT_SPC[$sp]
 	;;
-	sd  MOS_VC_REG_SPC[$r2], $p4
+	sw  MOS_VC_REG_SPC[$r2], $r4
 	;;
 
 	/* Restore shadow stack pointer. */

--- a/src/kernel/hal/arch/k1b/hooks.S
+++ b/src/kernel/hal/arch/k1b/hooks.S
@@ -119,7 +119,7 @@ _do_excp:
 	 */
 	k1b_context_save
 	;;
-	ld  $p2 = 8[$bp]            /* r0 + r1 */
+	ld  $p0 = 8[$bp]            /* r0 + r1 */
 	;;
 	sd  K1B_CONTEXT_R0[$sp], $p0
 	;;


### PR DESCRIPTION
Related Issues
--------------------

- [[k1b] Scratch Registers are Not Saved in the Execution Context](https://github.com/nanvix/microkernel/issues/113)
- [[k1b] Do Not Restore Stack Pointer](https://github.com/nanvix/microkernel/issues/114)
- [[k1b] mOS Uses 32-bit SPC Register](https://github.com/nanvix/microkernel/issues/115)