### PR TITLE
 [k1b] Bug Fix: Bad Function Epilogue

### DIFF
--- a/include/arch/k1b/regs.h
+++ b/include/arch/k1b/regs.h
@@ -76,11 +76,11 @@
 		add $sp, $sp, -STACK_FRAME_SIZE
 		;;
 
-		/* Save scratch registers (r0 and r1). */
+		/* Save r0 and r1 registers. */
 		sd 8[$sp] = $p0
 		;;
 
-		/* Save return address and stack base pointer. */
+		/* Save ra and bp registers. */
 		get $r0 = $ra
 		;;
 		copy $r1 = $bp
@@ -95,6 +95,18 @@
 	.endm
 
 	.macro _do_epilogue
+
+		/* Restore bp and ra registers. */
+		ld $p0 = 0[$sp]
+		;;
+		set $ra = $r0
+		;;
+		copy $bp = $r1
+		;;
+
+		/* Restore r0 and r1 registers. */
+		ld $p0 = 8[$sp]
+		;;
 
 		/* Wipe out frame. */
 		add $sp, $sp, STACK_FRAME_SIZE

--- a/include/nanvix/thread.h
+++ b/include/nanvix/thread.h
@@ -89,6 +89,11 @@
 	EXTERN struct thread threads[KTHREAD_MAX];
 
 	/**
+	 * @brief NULL thread ID.
+	 */
+	#define KTHREAD_NULL_TID -1
+
+	/**
 	 * @brief Master thread.
 	 */
 	#define KTHREAD_MASTER (&threads[0])


### PR DESCRIPTION
Previously, we were forgetting to restore scratch registers pushed onto
the stack by the do_prologue macro. In this commit, I have fixed this
bug.