### PR TITLE
[or1k] Bug Fix: Calling Notify When Core Is Already Locked

### DIFF
--- a/src/kernel/hal/arch/or1k/core.c
+++ b/src/kernel/hal/arch/or1k/core.c
@@ -131,12 +131,8 @@ PRIVATE inline void or1k_core_notify(int coreid)
 {
 	int mycoreid = or1k_core_get_id();
 
-	or1k_spinlock_lock(&cores[coreid].lock);
-
-		/* Set the pending IPI flag. */
-		pending_ipis[coreid] |= (1 << mycoreid);
-
-	or1k_spinlock_unlock(&cores[coreid].lock);
+	/* Set the pending IPI flag. */
+	pending_ipis[coreid] |= (1 << mycoreid);
 }
 
 /*============================================================================*
@@ -296,7 +292,6 @@ again:
 		cores[coreid].wakeups = 0;
 		or1k_dcache_inval();
 
-		or1k_spinlock_unlock(&cores[coreid].lock);
 		or1k_core_notify(coreid);
 	}
 


### PR DESCRIPTION
When the function or1k_core_notify() is called from or1k_core_wakeup(), core_notify() tries to lock an already locked core, so this PR solves this by just moving the or1k_core_notify() to after the critical section...