### PR TITLE
[or1k] Bug Fix: Errno Definition

### DIFF
--- a/src/libs/makefile
+++ b/src/libs/makefile
@@ -23,6 +23,7 @@
 #
 
 # Source Files
-SRC = $(wildcard nanvix/$(ARCH)/*.c)
+SRC = $(wildcard nanvix/$(ARCH)/*.c) \
+	$(wildcard nanvix/errno.c)
 
 include build/makefile.$(TARGET)

--- a/src/libs/nanvix/errno.c
+++ b/src/libs/nanvix/errno.c
@@ -1,0 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2019 Davidson Francis <davidsondfgl@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @brief Number of last error.
+ */ 
+int errno = 0;


### PR DESCRIPTION
Although the kernel has the errno variable declaration, it's definition can not be found anywhere, thus, this PR introduces the variable as part of the library.