### PR TITLE
[or1k] Feature: OpenRISC Syscalls Support

### DIFF
--- a/src/kernel/hal/arch/or1k/hooks.S
+++ b/src/kernel/hal/arch/or1k/hooks.S
@@ -407,7 +407,51 @@ _do_hwint:
  * System call hook.
  */
 _syscall:
+	_do_prologue
+	redzone_alloc
+
+	/*
+	 * Save execution context
+	 * in the current stack.
+	 */
+	l.addi sp, sp, -OR1K_CONTEXT_SIZE
+	or1k_context_save sp
+
+	/*
+	 * Syscall parameters.
+	 */
+	l.lwz r3, OR1K_CONTEXT_R13(sp) /* arg6. */
+	l.sw -8(sp), r3
+	l.lwz r3, OR1K_CONTEXT_R11(sp) /* syscall_nr */
+	l.sw -4(sp), r3
+
+	l.lwz r8, OR1K_CONTEXT_R8(sp)  /* arg5. */
+	l.lwz r7, OR1K_CONTEXT_R7(sp)  /* arg4. */
+	l.lwz r6, OR1K_CONTEXT_R6(sp)  /* arg3. */
+	l.lwz r5, OR1K_CONTEXT_R5(sp)  /* arg2. */
+	l.lwz r4, OR1K_CONTEXT_R4(sp)  /* arg1. */
+	l.lwz r3, OR1K_CONTEXT_R3(sp)  /* arg0. */
+
+	l.addi sp, sp, -8
+
+	/*
+	 * Call syscall handler.
+	 */
+	l.jal do_syscall1
 	l.nop
+	l.addi sp, sp, 8
+
+	/* Copy return value to the user stack. */
+	l.sw OR1K_CONTEXT_R11(sp), r11
+
+	/*
+	 * Restore saved execution context.
+	 */
+	or1k_context_restore sp
+
+	_do_epilogue
+
+	l.rfe
 	l.nop
 
 /*===========================================================================*

--- a/src/libs/nanvix/or1k/_exit.c
+++ b/src/libs/nanvix/or1k/_exit.c
@@ -24,47 +24,26 @@
  */
 
 #include <nanvix/syscall.h>
-#include <sys/types.h>
-#include <errno.h>
 
 /**
- * @brief Writes data to a file.
+ * @brief Terminates the calling process.
  *
- * @param fd  File descriptor.
- * @param buf Target buffer.
- * @param n   Number of bytes to write.
+ * @param status Exit status.
  *
- * @returns Upon successful completion, the number of bytes written is
- * returned. Upon failure, -1 is returned and @p errno is set to
- * indicate the error.
+ * @note This function does not return.
  */
-ssize_t nanvix_write(int fd, const char *buf, size_t n)
+void _exit(int status)
 {
 	register unsigned arg0
-		__asm__("r3") = (unsigned) fd;
-	register unsigned arg1
-		__asm__("r4") = (unsigned) buf;
-	register unsigned arg2
-		__asm__("r5") = (unsigned) n;
+		__asm__("r3") = (unsigned) status;
 
-	register ssize_t ret
-		__asm__("r11") = NR_write;
+	register int ret
+		__asm__("r11") = NR__exit;
 
 	__asm__ volatile (
 		"l.sys 1"
 		: "=r" (ret)
 		: "r" (ret),
-		"r" (arg0),
-		"r" (arg1),
-		"r" (arg2)
+		"r" (arg0)
 	);
-
-	/* System call failed. */
-	if (ret < 0)
-	{
-		errno = -ret;
-		return (-1);
-	}
-
-	return (ret);
 }

--- a/src/libs/nanvix/or1k/thread.c
+++ b/src/libs/nanvix/or1k/thread.c
@@ -2,6 +2,7 @@
  * MIT License
  *
  * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *              2018 Davidson Francis     <davidsondfgl@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +35,16 @@
  */
 kthread_t kthread_self(void)
 {
-	return (-1);
+	register kthread_t tid
+		__asm__("r11") = NR_thread_get_id;
+
+	__asm__ volatile (
+		"l.sys 1"
+		: "=r" (tid)
+		: "r"  (tid)
+	);
+
+	return (tid);
 }
 
 /*============================================================================*
@@ -50,11 +60,33 @@ int kthread_create(
 	void *arg
 )
 {
-	((void) tid);
-	((void) start);
-	((void) arg);
+	register unsigned arg0
+		__asm__("r3") = (unsigned) tid;
+	register unsigned arg1
+		__asm__("r4") = (unsigned) start;
+	register unsigned arg2
+		__asm__("r5") = (unsigned) arg;
 
-	return (-1);
+	register int ret
+		__asm__("r11") = NR_thread_create;
+
+	__asm__ volatile (
+		"l.sys 1"
+		: "=r" (ret)
+		: "r" (ret),
+		"r" (arg0),
+		"r" (arg1),
+		"r" (arg2)
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
 }
 
 /*============================================================================*
@@ -66,9 +98,27 @@ int kthread_create(
  */
 int kthread_exit(void *retval)
 {
-	((void) retval);
-	
-	return (-1);
+	register unsigned arg0
+		__asm__("r3") = (unsigned) retval;
+
+	register int ret
+		__asm__("r11") = NR_thread_exit;
+
+	__asm__ volatile (
+		"l.sys 1"
+		: "=r" (ret)
+		: "r" (ret),
+		"r" (arg0)
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
 }
 
 /*============================================================================*
@@ -83,10 +133,30 @@ int kthread_join(
 	void **retval
 )
 {
-	((void) tid);
-	((void) retval);
+	register unsigned arg0
+		__asm__("r3") = (unsigned) tid;
+	register unsigned arg1
+		__asm__("r4") = (unsigned) retval;
 
-	return (-1);
+	register int ret
+		__asm__("r11") = NR_thread_join;
+
+	__asm__ volatile (
+		"l.sys 1"
+		: "=r" (ret)
+		: "r" (ret),
+		"r" (arg0),
+		"r" (arg1)
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
 }
 
 /*============================================================================*
@@ -98,7 +168,23 @@ int kthread_join(
  */
 int sleep(void)
 {
-	return (-1);
+	register int ret
+		__asm__("r11") = NR_sleep;
+
+	__asm__ volatile (
+		"l.sys 1"
+		: "=r" (ret)
+		: "r"  (ret)
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
 }
 
 /*============================================================================*
@@ -110,7 +196,25 @@ int sleep(void)
  */
 int wakeup(kthread_t tid)
 {
-	((void) (tid));
+	register unsigned arg0
+		__asm__("r3") = (unsigned) tid;
 
-	return (-1);
+	register int ret
+		__asm__("r11") = NR_wakeup;
+
+	__asm__ volatile (
+		"l.sys 1"
+		: "=r" (ret)
+		: "r" (ret),
+		"r" (arg0)
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
 }


### PR DESCRIPTION
Until now the OpenRISC architecture does not have syscalls support, so this PR implements the syscall handler and the equivalent function wrappers.

It's highly recommended that this PR be merged after the PR #132, in order to avoid unexpected behaviors.