### PR TITLE
[kcall] Signals

### DIFF
--- a/include/nanvix.h
+++ b/include/nanvix.h
@@ -124,10 +124,59 @@
  * Signal                                                                     *
  *============================================================================*/
 
+	/**
+	 * @brief Controls the behavior of a signal.
+	 *
+	 * The sigclt() function modifies the treatment of a signal.
+     * 
+     * @param signum Signal ID.
+     * @param sigact Behavior descriptor.
+	 *
+	 * @returns Zero if successfully changes the behavior, non zero otherwise.
+	 */
 	extern int ksigclt(int signum, struct sigaction * sigact);
+
+	/**
+	 * @brief Schedules an alarm signal.
+	 *
+	 * The kalarm() function schedule an alarm signal to trigger when
+     * the @seconds seconds pass.
+     *
+     * @param seconds Time in seconds.
+	 *
+	 * @returns Zero if successfully register the alarm, non zero otherwise.
+	 */
 	extern int kalarm(int seconds);
+
+	/**
+	 * @brief Sends a signal.
+	 *
+	 * The ksigsend() function sends a signal @signum to another thread @tid.
+     * 
+     * @param signum Signal ID.
+     * @param tid    Thread ID.
+	 *
+	 * @returns Zero if successfully sends the signal, non zero otherwise.
+	 */
 	extern int ksigsend(int signum, int tid);
+
+	/**
+	 * @brief Waits for the receipt of a signal.
+	 *
+	 * The ksigwait() function waits for the receipt of a @signum signal.
+     *
+     * @param signum Signal ID.
+	 *
+	 * @returns Zero if successfully receives the signal, non zero otherwise.
+	 */
 	extern int ksigwait(int signum);
+
+	/**
+	 * @brief Returns from a signal handler.
+	 *
+	 * The ksigreturn() function returns from a signal handler, restoring the
+     * execution stream.
+	 */
 	extern int ksigreturn(void);
 
 /*============================================================================*

--- a/include/nanvix.h
+++ b/include/nanvix.h
@@ -121,6 +121,16 @@
 	extern uint64_t nanvix_perf_read(int perf);
 
 /*============================================================================*
+ * Signal                                                                     *
+ *============================================================================*/
+
+	extern int ksigclt(int signum, struct sigaction * sigact);
+	extern int kalarm(int seconds);
+	extern int ksigsend(int signum, int tid);
+	extern int ksigwait(int signum);
+	extern int ksigreturn(void);
+
+/*============================================================================*
  * Mutex                                                                      *
  *============================================================================*/
 

--- a/include/nanvix/mm.h
+++ b/include/nanvix/mm.h
@@ -40,6 +40,14 @@
 /**@{*/
 
 	/**
+	 * @name Memory area identification
+	 */
+	/**@{*/
+	#define KMEM_AREA 0 /**< Kernel memory area. */
+	#define UMEM_AREA 1 /**< User memory area.   */
+	/**@}*/
+
+	/**
 	 * @brief Initializes the Memory Management (MM) system.
 	 */
 	EXTERN void mm_init(void);
@@ -73,6 +81,31 @@
 			((vaddr >= KBASE_VIRT) && (vaddr < (KBASE_VIRT + KMEM_SIZE)))  ||
 			((vaddr >= KPOOL_VIRT) && (vaddr < (KPOOL_VIRT + KPOOL_SIZE)))
 		);
+	}
+
+	/**
+	 * @brief Checks access permissions to a memory area.
+	 * 
+	 * @param addr Address to be checked.
+	 * @param size Size of memory area.
+	 * @param area User memory area.
+	 * 
+	 * @returns Non-zero if access is authorized, and zero otherwise.
+	 */
+	static inline int mm_check_area(vaddr_t vaddr, uint64_t size, int area)
+	{
+	#ifndef __mppa256__
+		if (area == UMEM_AREA)
+			return mm_is_uaddr(vaddr) && mm_is_uaddr(vaddr + size);
+		else
+			return mm_is_kaddr(vaddr) && mm_is_kaddr(vaddr + size);
+	#else
+		UNUSED(vaddr);
+		UNUSED(size);
+		UNUSED(area);
+
+		return (1);
+	#endif
 	}
 
 /**@}*/

--- a/include/nanvix/signal.h
+++ b/include/nanvix/signal.h
@@ -1,0 +1,142 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @defgroup kernel- Signal System
+ * @ingroup kernel
+ *
+ * @brief Signal System
+ */
+
+#ifndef NANVIX_SIGNAL_H_
+#define NANVIX_SIGNAL_H_
+
+	/* External dependencies. */
+	#include <nanvix/hal/hal.h>
+	#include <nanvix/const.h>
+
+/*============================================================================*
+ *                                Signal System                               *
+ *============================================================================*/
+
+	/**
+	 * @name Signal types
+	 */
+	/**@{*/
+	#define SIGOPCODE  EXCEPTION_INVALID_OPCODE     /**< Invalid opcode signal     */
+	#define SIGPGFAULT EXCEPTION_PAGE_FAULT         /**< Page fault signal         */
+	#define SIGPGPROT  EXCEPTION_PAGE_PROTECTION    /**< Page protection signal    */
+	#define SIGGENPROT EXCEPTION_GENERAL_PROTECTION /**< General protection signal */
+	/**@}*/
+
+	/**
+	 * @brief Signal Action handler.
+	 */
+	typedef void (*sa_handler)(void *);
+
+	/**
+	 * @brief Signal Action struct (Partial POSIX specification).
+	 */
+	struct sigaction
+	{
+        sa_handler handler; /**< Pointer to a signal-catching function. */
+	};
+
+	/**
+	 * @brief Controls the behavior of a signal.
+	 *
+	 * The sigclt() function modifies the treatment of a signal.
+     * 
+     * @param signum Signal ID.
+     * @param sigact Behavior descriptor.
+	 *
+	 * @returns Zero if successfully changes the behavior, non zero otherwise.
+	 */
+	EXTERN int sigclt(int signum, struct sigaction * sigact);
+
+	/**
+	 * @brief Schedules an alarm signal.
+	 *
+	 * The alarm() function schedule an alarm signal to trigger when
+     * the @seconds seconds pass.
+     *
+     * @param seconds Time in seconds.
+	 *
+	 * @returns Zero if successfully register the alarm, non zero otherwise.
+	 */
+	static int alarm(int seconds)
+    {
+        UNUSED(seconds);
+
+        return (0);
+    }
+
+	/**
+	 * @brief Sends a signal.
+	 *
+	 * The sigsend() function sends a signal @signum to another thread @tid.
+     * 
+     * @param signum Signal ID.
+     * @param tid    Thread ID.
+	 *
+	 * @returns Zero if successfully sends the signal, non zero otherwise.
+	 */
+	static int sigsend(int signum, int tid)
+    {
+        UNUSED(signum);
+        UNUSED(tid);
+
+        return (0);
+    }
+
+	/**
+	 * @brief Waits for the receipt of a signal.
+	 *
+	 * The sigwait() function waits for the receipt of a @signum signal.
+     *
+     * @param signum Signal ID.
+	 *
+	 * @returns Zero if successfully receives the signal, non zero otherwise.
+	 */
+	static inline int sigwait(int signum)
+    {
+        UNUSED(signum);
+
+        return (0);
+    }
+
+	/**
+	 * @brief Returns from a signal handler.
+	 *
+	 * The sigreturn() function returns from a signal handler, restoring the
+     * execution stream.
+	 */
+	static inline void sigreturn()
+    {
+
+    }
+
+#endif /* NANVIX_SIGNAL_H_ */
+
+/**@}*/

--- a/include/nanvix/signal.h
+++ b/include/nanvix/signal.h
@@ -60,16 +60,16 @@
 	 */
 	struct sigaction
 	{
-        sa_handler handler; /**< Pointer to a signal-catching function. */
+		sa_handler handler; /**< Pointer to a signal-catching function. */
 	};
 
 	/**
 	 * @brief Controls the behavior of a signal.
 	 *
 	 * The sigclt() function modifies the treatment of a signal.
-     * 
-     * @param signum Signal ID.
-     * @param sigact Behavior descriptor.
+	 *
+	 * @param signum Signal ID.
+	 * @param sigact Behavior descriptor.
 	 *
 	 * @returns Zero if successfully changes the behavior, non zero otherwise.
 	 */
@@ -79,63 +79,63 @@
 	 * @brief Schedules an alarm signal.
 	 *
 	 * The alarm() function schedule an alarm signal to trigger when
-     * the @seconds seconds pass.
-     *
-     * @param seconds Time in seconds.
+	 * the @seconds seconds pass.
+	 *
+	 * @param seconds Time in seconds.
 	 *
 	 * @returns Zero if successfully register the alarm, non zero otherwise.
 	 */
 	static int alarm(int seconds)
-    {
-        UNUSED(seconds);
+	{
+		UNUSED(seconds);
 
-        return (0);
-    }
+		return (0);
+	}
 
 	/**
 	 * @brief Sends a signal.
 	 *
 	 * The sigsend() function sends a signal @signum to another thread @tid.
-     * 
-     * @param signum Signal ID.
-     * @param tid    Thread ID.
+	 *
+	 * @param signum Signal ID.
+	 * @param tid    Thread ID.
 	 *
 	 * @returns Zero if successfully sends the signal, non zero otherwise.
 	 */
 	static int sigsend(int signum, int tid)
-    {
-        UNUSED(signum);
-        UNUSED(tid);
+	{
+		UNUSED(signum);
+		UNUSED(tid);
 
-        return (0);
-    }
+		return (0);
+	}
 
 	/**
 	 * @brief Waits for the receipt of a signal.
 	 *
 	 * The sigwait() function waits for the receipt of a @signum signal.
-     *
-     * @param signum Signal ID.
+	 *
+	 * @param signum Signal ID.
 	 *
 	 * @returns Zero if successfully receives the signal, non zero otherwise.
 	 */
 	static inline int sigwait(int signum)
-    {
-        UNUSED(signum);
+	{
+		UNUSED(signum);
 
-        return (0);
-    }
+		return (0);
+	}
 
 	/**
 	 * @brief Returns from a signal handler.
 	 *
 	 * The sigreturn() function returns from a signal handler, restoring the
-     * execution stream.
+	 * execution stream.
 	 */
-	static inline void sigreturn()
-    {
+	static inline void sigreturn(void)
+	{
 
-    }
+	}
 
 #endif /* NANVIX_SIGNAL_H_ */
 

--- a/include/nanvix/syscall.h
+++ b/include/nanvix/syscall.h
@@ -146,9 +146,9 @@
 	 * @brief Controls the behavior of a signal.
 	 *
 	 * The sigclt() function modifies the treatment of a signal.
-     * 
-     * @param signum Signal ID.
-     * @param sigact Behavior descriptor.
+	 *
+	 * @param signum Signal ID.
+	 * @param sigact Behavior descriptor.
 	 *
 	 * @returns Zero if successfully changes the behavior, non zero otherwise.
 	 */
@@ -158,9 +158,9 @@
 	 * @brief Schedules an alarm signal.
 	 *
 	 * The alarm() function schedule an alarm signal to trigger when
-     * the @seconds seconds pass.
-     *
-     * @param seconds Time in seconds.
+	 * the @seconds seconds pass.
+	 *
+	 * @param seconds Time in seconds.
 	 *
 	 * @returns Zero if successfully register the alarm, non zero otherwise.
 	 */
@@ -170,9 +170,9 @@
 	 * @brief Sends a signal.
 	 *
 	 * The sigsend() function sends a signal @signum to another thread @tid.
-     * 
-     * @param signum Signal ID.
-     * @param tid    Thread ID.
+	 *
+	 * @param signum Signal ID.
+	 * @param tid    Thread ID.
 	 *
 	 * @returns Zero if successfully sends the signal, non zero otherwise.
 	 */
@@ -182,8 +182,8 @@
 	 * @brief Waits for the receipt of a signal.
 	 *
 	 * The sigwait() function waits for the receipt of a @signum signal.
-     *
-     * @param signum Signal ID.
+	 *
+	 * @param signum Signal ID.
 	 *
 	 * @returns Zero if successfully receives the signal, non zero otherwise.
 	 */
@@ -193,7 +193,7 @@
 	 * @brief Returns from a signal handler.
 	 *
 	 * The sigreturn() function returns from a signal handler, restoring the
-     * execution stream.
+	 * execution stream.
 	 */
 	EXTERN void sys_sigreturn(void);
 

--- a/include/nanvix/syscall.h
+++ b/include/nanvix/syscall.h
@@ -30,6 +30,7 @@
 
 	#include <nanvix/const.h>
 	#include <nanvix/thread.h>
+	#include <nanvix/signal.h>
 
 /**
  * @addtogroup kernel-syscalls System Calls
@@ -42,7 +43,7 @@
 	 *
 	 * @note This should be set to the highest system call number.
 	 */
-	#define NR_SYSCALLS 14
+	#define NR_SYSCALLS 18
 
 	/**
 	 * @name System Call Numbers
@@ -61,6 +62,11 @@
 	#define NR_perf_start   11 /**< sys_perf_start()    */
 	#define NR_perf_stop    12 /**< sys_perf_stop()     */
 	#define NR_perf_read    13 /**< sys_perf_read()     */
+	#define NR_sigclt       14 /**< sys_perf_read()     */
+	#define NR_alarm        15 /**< sys_perf_read()     */
+	#define NR_sigsend      16 /**< sys_perf_read()     */
+	#define NR_sigwait      17 /**< sys_perf_read()     */
+	#define NR_sigreturn    18 /**< sys_perf_read()     */
 	/**@}*/
 
 	EXTERN void sys_exit(int);
@@ -123,6 +129,12 @@
 	 * converted to uint64_t is returned instead.
 	 */
 	EXTERN uint64_t sys_perf_read(int perf);
+
+	EXTERN int sys_sigclt(int signum, struct sigaction * sigact);
+	EXTERN int sys_alarm(int seconds);
+	EXTERN int sys_sigsend(int signum, int tid);
+	EXTERN int sys_sigwait(int signum);
+	EXTERN void sys_sigreturn(void);
 
 /**@}*/
 

--- a/include/nanvix/syscall.h
+++ b/include/nanvix/syscall.h
@@ -43,7 +43,7 @@
 	 *
 	 * @note This should be set to the highest system call number.
 	 */
-	#define NR_SYSCALLS 18
+	#define NR_SYSCALLS 19
 
 	/**
 	 * @name System Call Numbers
@@ -69,6 +69,10 @@
 	#define NR_sigreturn    18 /**< sys_perf_read()     */
 	/**@}*/
 
+/*============================================================================*
+ *                            Thread system syscalls                          *
+ *============================================================================*/
+
 	EXTERN void sys_exit(int);
 	EXTERN ssize_t sys_write(int, const char *, size_t);
 	EXTERN int sys_thread_get_id(void);
@@ -85,6 +89,10 @@
 	 * return.Upon failure, a negative error code is returned instead.
 	 */
 	EXTERN int sys_shutdown(void);
+
+/*============================================================================*
+ *                              Perf System syscalls                          *
+ *============================================================================*/
 
 	/**
 	 * @brief Queries a performance event.
@@ -130,10 +138,63 @@
 	 */
 	EXTERN uint64_t sys_perf_read(int perf);
 
+/*============================================================================*
+ *                           Signal system syscalls                           *
+ *============================================================================*/
+
+	/**
+	 * @brief Controls the behavior of a signal.
+	 *
+	 * The sigclt() function modifies the treatment of a signal.
+     * 
+     * @param signum Signal ID.
+     * @param sigact Behavior descriptor.
+	 *
+	 * @returns Zero if successfully changes the behavior, non zero otherwise.
+	 */
 	EXTERN int sys_sigclt(int signum, struct sigaction * sigact);
+
+	/**
+	 * @brief Schedules an alarm signal.
+	 *
+	 * The alarm() function schedule an alarm signal to trigger when
+     * the @seconds seconds pass.
+     *
+     * @param seconds Time in seconds.
+	 *
+	 * @returns Zero if successfully register the alarm, non zero otherwise.
+	 */
 	EXTERN int sys_alarm(int seconds);
+
+	/**
+	 * @brief Sends a signal.
+	 *
+	 * The sigsend() function sends a signal @signum to another thread @tid.
+     * 
+     * @param signum Signal ID.
+     * @param tid    Thread ID.
+	 *
+	 * @returns Zero if successfully sends the signal, non zero otherwise.
+	 */
 	EXTERN int sys_sigsend(int signum, int tid);
+
+	/**
+	 * @brief Waits for the receipt of a signal.
+	 *
+	 * The sigwait() function waits for the receipt of a @signum signal.
+     *
+     * @param signum Signal ID.
+	 *
+	 * @returns Zero if successfully receives the signal, non zero otherwise.
+	 */
 	EXTERN int sys_sigwait(int signum);
+
+	/**
+	 * @brief Returns from a signal handler.
+	 *
+	 * The sigreturn() function returns from a signal handler, restoring the
+     * execution stream.
+	 */
 	EXTERN void sys_sigreturn(void);
 
 /**@}*/

--- a/src/kernel/pm/cond.c
+++ b/src/kernel/pm/cond.c
@@ -82,7 +82,7 @@ PUBLIC int cond_broadcast(struct condvar *cond)
 	spinlock_lock(&cond->lock);
 
 		/* Wakeup all threads. */
-		while (cond->queue != NULL)
+		while (UNLIKELY(cond->queue != NULL))
 		{
 			thread_wakeup(cond->queue);
 			cond->queue = cond->queue->next;

--- a/src/kernel/pm/signal.c
+++ b/src/kernel/pm/signal.c
@@ -1,0 +1,111 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/hal/hal.h>
+#include <nanvix/const.h>
+#include <nanvix/signal.h>
+#include <errno.h>
+
+
+/**
+ * @brief Information about signal.
+ */
+EXTENSION PRIVATE struct signal_info
+{
+	sa_handler handler; /**< Handler */
+} ALIGN(sizeof(dword_t)) signals[EXCEPTIONS_NUM] = {
+	[0 ... (EXCEPTIONS_NUM - 1)] = {
+		.handler = NULL
+	},
+};
+
+/**
+ * @brief Signal handler
+ */
+PRIVATE void signal_handler(
+	const struct exception *excp,
+	const struct context *ctx
+)
+{
+	word_t signum;
+
+	signum = excp->num;
+
+	if (signals[signum].handler)
+	{
+		/* Forge upcall. */
+		upcall_forge(
+			(struct context *) ctx,
+			signals[signum].handler,
+			&signum,
+			sizeof(word_t)
+		);
+	}
+}
+
+/*============================================================================*
+ * sigclt()                                                                   *
+ *============================================================================*/
+
+/**
+ * @brief Controls the behavior of a signal.
+ *
+ * The sigclt() function modifies the treatment of a signal.
+ *
+ * @param signum Signal ID.
+ * @param sigact Behavior descriptor.
+ *
+ * @returns Zero if successfully changes the behavior, non zero otherwise.
+ */
+PUBLIC int sigclt(int signum, struct sigaction * sigact)
+{
+	int ret;
+
+	/* Invalid signal ID. */
+	if ((signum < 0) || (signum >= EXCEPTIONS_NUM))
+		return (-EINVAL);
+
+	/* Unchanged the signal. */
+	if (sigact == NULL)
+		return (-EAGAIN);
+
+	if (sigact->handler != NULL)
+	{
+		ret = 0;
+
+		if (signals[signum].handler == NULL)
+			ret = exception_register(signum, signal_handler);
+	}
+	else
+		ret = exception_unregister(signum);
+
+	if (ret != 0)
+		return (ret);
+
+	signals[signum].handler = sigact->handler;
+
+	dcache_invalidate();
+
+	return 0;
+}

--- a/src/kernel/sys/signal.c
+++ b/src/kernel/sys/signal.c
@@ -23,6 +23,7 @@
  */
 
 #include <nanvix/const.h>
+#include <nanvix/mm.h>
 #include <nanvix/signal.h>
 #include <errno.h>
 
@@ -33,8 +34,16 @@
 PUBLIC int sys_sigclt(int signum, struct sigaction * sigact)
 {
 	if (sigact == NULL)
-		return (-EINVAL);
-	
+		return (-EAGAIN);
+
+	/* Bad struct location. */
+	if (!mm_check_area(VADDR(sigact), sizeof(struct sigaction), UMEM_AREA))
+		return (-EFAULT);
+
+	/* Bad handler address. */
+	if (!mm_check_area(VADDR(sigact->handler), 0, UMEM_AREA))
+		return (-EFAULT);
+
 	return sigclt(signum, sigact);
 }
 

--- a/src/kernel/sys/signal.c
+++ b/src/kernel/sys/signal.c
@@ -1,0 +1,75 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/const.h>
+#include <nanvix/signal.h>
+#include <errno.h>
+
+/*============================================================================*
+ * sys_sigclt()                                                               *
+ *============================================================================*/
+
+PUBLIC int sys_sigclt(int signum, struct sigaction * sigact)
+{
+	if (sigact == NULL)
+		return (-EINVAL);
+	
+	return sigclt(signum, sigact);
+}
+
+/*============================================================================*
+ * sys_alarm()                                                                *
+ *============================================================================*/
+
+PUBLIC int sys_alarm(int seconds)
+{
+	return alarm(seconds);
+}
+
+/*============================================================================*
+ * sys_sigsend()                                                              *
+ *============================================================================*/
+
+PUBLIC int sys_sigsend(int signum, int tid)
+{
+	return sigsend(signum, tid);
+}
+
+/*============================================================================*
+ * sys_sigwait()                                                              *
+ *============================================================================*/
+
+PUBLIC int sys_sigwait(int signum)
+{
+	return sigwait(signum);
+}
+
+/*============================================================================*
+ * sys_sigreturn()                                                            *
+ *============================================================================*/
+
+PUBLIC void sys_sigreturn(void)
+{
+	sigreturn();
+}

--- a/src/kernel/sys/syscalls.c
+++ b/src/kernel/sys/syscalls.c
@@ -109,6 +109,13 @@ PUBLIC void do_syscall2(void)
 
 #endif
 
+			case NR_sigclt:
+				ret = sys_sigclt(
+					(int) sysboard[coreid].arg0,
+					(struct sigaction *) sysboard[coreid].arg1
+				);
+				break;
+
 			default:
 				break;
 		}
@@ -198,6 +205,26 @@ PUBLIC int do_syscall(
 			ret64 = sys_perf_read((int) arg0);
 			ret = (int)(ret64 & 0xffffffff);
 		} break;
+
+		case NR_alarm:
+			ret = sys_alarm((int) arg0);
+			break;
+
+		case NR_sigsend:
+			ret = sys_sigsend(
+				(int) arg0,
+				(int) arg1
+			);
+			break;
+
+		case NR_sigwait:
+			ret = sys_sigwait((int) arg0);
+			break;
+
+		case NR_sigreturn:
+			sys_sigreturn();
+			ret = 0;
+			break;
 
 		/* Forward system call. */
 		default:

--- a/src/kernel/sys/syscalls.c
+++ b/src/kernel/sys/syscalls.c
@@ -215,11 +215,9 @@ PUBLIC int do_syscall(
 			sysboard[coreid].syscall_nr = syscall_nr;
 			sysboard[coreid].pending = 1;
 			semaphore_init(&sysboard[coreid].syssem, 0);
-			dcache_invalidate();
 
 			semaphore_up(&syssem);
 			semaphore_down(&sysboard[coreid].syssem);
-			dcache_invalidate();
 
 			ret = sysboard[coreid].ret;
 		} break;

--- a/src/libs/nanvix/signal.c
+++ b/src/libs/nanvix/signal.c
@@ -1,0 +1,169 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *              2018 Davidson Francis     <davidsondfgl@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix.h>
+#include <errno.h>
+
+/*============================================================================*
+ * ksigclt()                                                                  *
+ *============================================================================*/
+
+/*
+ * @see sys_sigclt()
+ */
+int ksigclt(
+	int signum,
+	struct sigaction * sigact
+)
+{
+	int ret;
+
+	ret = syscall2(
+		NR_sigclt,
+		(word_t) signum,
+		(word_t) sigact
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	dcache_invalidate();
+
+	return (ret);
+}
+
+/*============================================================================*
+ * kalarm()                                                                   *
+ *============================================================================*/
+
+/*
+ * @see sys_alarm()
+ */
+int kalarm(int seconds)
+{
+	int ret;
+
+	ret = syscall1(
+		NR_alarm,
+		(word_t) seconds
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
+}
+
+/*============================================================================*
+ * ksigsend()                                                                 *
+ *============================================================================*/
+
+/*
+ * @see sys_sigsend().
+ */
+int ksigsend(int signum, int tid)
+{
+	int ret;
+
+	ret = syscall2(
+		NR_sigsend,
+		(word_t) signum,
+        (word_t) tid
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
+}
+
+/*============================================================================*
+ * ksigwait()                                                                 *
+ *============================================================================*/
+
+/*
+ * @see sys_sigwait()
+ */
+int ksigwait(
+	int signum
+)
+{
+	int ret;
+
+	ret = syscall1(
+		NR_sigwait,
+		(word_t) signum
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
+}
+
+/*============================================================================*
+ * ksigreturn()                                                               *
+ *============================================================================*/
+
+/*
+ * @see sys_sigreturn()
+ */
+int ksigreturn(void)
+{
+	int ret;
+
+	ret = syscall0(
+		NR_sigreturn
+	);
+
+	/* System call failed. */
+	if (ret < 0)
+	{
+		errno = -ret;
+		return (-1);
+	}
+
+	return (ret);
+}
+
+	
+
+

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -93,6 +93,7 @@ static struct
 	{ test_nanvix_perf_api_read, "[test][user][api] read performance monitor       [passed]\n"  },
 #endif
 	{ test_api_signal_action,    "[test][user][api] signal (un)register behavior   [passed]\n"  },
+	{ test_fault_signal_action,  "[test][user][fault] signal (un)register behavior [passed]\n"  },
 	{ NULL,                       NULL                                                          },
 };
 

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -92,6 +92,7 @@ static struct
 #if (CORE_HAS_PERF)
 	{ test_nanvix_perf_api_read, "[test][user][api] read performance monitor       [passed]\n"  },
 #endif
+	{ test_api_signal_action,    "[test][user][api] signal (un)register behavior   [passed]\n"  },
 	{ NULL,                       NULL                                                          },
 };
 

--- a/src/test/signal.c
+++ b/src/test/signal.c
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+ *              2015-2016 Davidson Francis     <davidsondfgl@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix.h>
+#include "test.h"
+
+/**
+ * @cond release_test
+ */
+
+/**
+ * @brief Enable destructive testing.
+ */
+#define SIGNAL_DESTRUCTIVE_TEST 0
+
+/*============================================================================*
+ * Signal Unit Tests                                                          *
+ *============================================================================*/
+
+/**
+ * @brief Auxiliar handler
+ *
+ * @author João Vicente Souto
+ */
+static void dummy_handler(void * arg)
+{
+	int signum = *((int *) arg);
+
+	KASSERT(signum == SIGPGFAULT);
+}
+
+/**
+ * @brief API Test: Register and unregister a handler
+ *
+ * @author João Vicente Souto
+ */
+void test_api_signal_action(void)
+{
+	struct sigaction sigact;
+
+	sigact.handler = dummy_handler;
+
+	KASSERT(ksigclt(SIGPGFAULT, &sigact) == 0);
+
+#if (SIGNAL_DESTRUCTIVE_TEST)
+	
+	int b;
+	int *a = (int *) 0xdeadbeef;
+	
+	/* Page fault (Infinite loop) */
+	b = *a;
+
+	UNUSED(b);
+#endif
+
+	sigact.handler = NULL;
+
+	KASSERT(ksigclt(SIGPGFAULT, &sigact) == 0);
+}
+
+/*============================================================================*/
+
+/**@endcond*/

--- a/src/test/signal.c
+++ b/src/test/signal.c
@@ -44,9 +44,9 @@
  *
  * @author João Vicente Souto
  */
-static void dummy_handler(void * arg)
+void dummy_handler(void * arg)
 {
-	int signum = *((int *) arg);
+	dword_t signum = *((dword_t *) arg);
 
 	KASSERT(signum == SIGPGFAULT);
 }
@@ -65,10 +65,10 @@ void test_api_signal_action(void)
 	KASSERT(ksigclt(SIGPGFAULT, &sigact) == 0);
 
 #if (SIGNAL_DESTRUCTIVE_TEST)
-	
+
 	int b;
 	int *a = (int *) 0xdeadbeef;
-	
+
 	/* Page fault (Infinite loop) */
 	b = *a;
 

--- a/src/test/signal.c
+++ b/src/test/signal.c
@@ -80,6 +80,34 @@ void test_api_signal_action(void)
 	KASSERT(ksigclt(SIGPGFAULT, &sigact) == 0);
 }
 
+/**
+ * @brief Fault Test: Register and unregister a handler
+ *
+ * @author João Vicente Souto
+ */
+void test_fault_signal_action(void)
+{
+	struct sigaction sigact;
+
+	sigact.handler = NULL;
+
+	/* Invalid Signal ID */
+	KASSERT(ksigclt(-1, &sigact) < 0);
+	KASSERT(ksigclt(EXCEPTIONS_NUM, &sigact) < 0);
+	KASSERT(ksigclt(EXCEPTIONS_NUM+1, &sigact) < 0);
+
+	/* Invalid sigaction */
+	KASSERT(ksigclt(SIGPGFAULT, NULL) < 0);
+
+	sigact.handler = dummy_handler;
+	KASSERT(ksigclt(SIGPGFAULT, &sigact) == 0);
+	KASSERT(ksigclt(SIGPGFAULT, NULL) < 0);
+
+	sigact.handler = NULL;
+	KASSERT(ksigclt(SIGPGFAULT, &sigact) == 0);
+	KASSERT(ksigclt(SIGPGFAULT, NULL) < 0);
+}
+
 /*============================================================================*/
 
 /**@endcond*/

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -53,6 +53,7 @@
 	extern void test_stress_sleep_wakeup(void);
 	extern void test_nanvix_perf_api_read(void);
 	extern void test_api_signal_action(void);
+	extern void test_fault_signal_action(void);
 	/**@}*/
 
 	/**

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -52,6 +52,7 @@
 	extern void test_fault_sleep_wakeup(void);
 	extern void test_stress_sleep_wakeup(void);
 	extern void test_nanvix_perf_api_read(void);
+	extern void test_api_signal_action(void);
 	/**@}*/
 
 	/**


### PR DESCRIPTION
Description
---------------
In this PR, I introduce a simple signal interface dealing directly with the exceptions.
Specifically, only sigclt() function has implemented for use by the benchmarks of upcall..

Related Issues
--------------------
- [[kcalls] Signal Kernel Calls](https://github.com/nanvix/microkernel/issues/85)
- [[test] Unit Tests for Signals](https://github.com/nanvix/microkernel/issues/148)