### PR TITLE
[build] Bug Fix: OpTiMSoC Build

### DIFF
--- a/build/optimsoc/make/makefile
+++ b/build/optimsoc/make/makefile
@@ -28,7 +28,7 @@
 
 export CFLAGS  = -D __optimsoc__     # Target
 export CFLAGS += -D __optimsoc4__    # Processor
-export CFLAGS += -D __or1k_cluster__ # CLuster
+export CFLAGS += -D __optimsoc_cluster__ # CLuster
 export CFLAGS += -D __or1k__         # Core
 export CFLAGS += -D __mor1kx__       # Core Variant
 

--- a/build/optimsoc/make/makefile
+++ b/build/optimsoc/make/makefile
@@ -47,7 +47,8 @@ export AR = $(TOOLCHAIN_DIR)/or1k-elf-ar
 # Compiler Options
 export CFLAGS  += -Wstack-usage=4096
 export CFLAGS  += -nostdlib -nostdinc
-export CFLAGS += -I $(INCDIR)/posix
+export CFLAGS  += -Wno-type-limits
+export CFLAGS  += -I $(INCDIR)/posix
 
 # Linker Options
 export LDFLAGS  += -nostdlib -nostdinc

--- a/build/qemu-openrisc/make/makefile
+++ b/build/qemu-openrisc/make/makefile
@@ -48,7 +48,7 @@ export AR = $(TOOLCHAIN_DIR)/or1k-elf-ar
 export CFLAGS += -D __HAS_HW_DIVISION
 export CFLAGS += -Wstack-usage=4096
 export CFLAGS += -nostdlib -nostdinc
-export CFLAGS += -Wno-error=type-limits
+export CFLAGS += -Wno-type-limits
 export CFLAGS += -I $(INCDIR)/posix
 
 # Linker Options


### PR DESCRIPTION
Description
---------------
The OpTiMSoC target was not building due the a wrong cluster in the makefile, this PR fixes it by changing to the right cluster in the build flags.

Related Issues
--------------------
- [[build] OpTiMSoC Build Is Failing](https://github.com/nanvix/microkernel/issues/151)