### PR TITLE
[openrisc] Wrong Check in Memory Area

### DIFF
--- a/include/nanvix/mm.h
+++ b/include/nanvix/mm.h
@@ -94,13 +94,21 @@
 	 */
 	static inline int mm_check_area(vaddr_t vaddr, uint64_t size, int area)
 	{
-	#ifndef __mppa256__
+	#if !defined(__mppa256__)       && \
+		!defined(__optimsoc__)      && \
+		!defined(__qemu_openrisc__)
 
 		return (
 			(area == UMEM_AREA) ?
 				mm_is_uaddr(vaddr) && mm_is_uaddr(vaddr + size) :
 				mm_is_kaddr(vaddr) && mm_is_kaddr(vaddr + size)
 		);
+
+	#elif defined(__optimsoc__)    || \
+		defined(__qemu_openrisc__)
+
+		UNUSED(area);
+		return (mm_is_kaddr(vaddr) && mm_is_kaddr(vaddr + size));
 
 	#else
 


### PR DESCRIPTION
Description
---------------
Since the optimsoc and qemu-openrisc targets still run in kernel mode, all data will belong to the kernel space, not user space. Therefore, the function mm_check_area() was leading to misbehaviour during the signals tests, since the sigact pointer belongs to the kernel space.

This PR fixes it by checking only for the kernel addresses.