### PR TITLE
[tm] Kernel Thread Number

### DIFF
--- a/include/nanvix/thread.h
+++ b/include/nanvix/thread.h
@@ -77,6 +77,7 @@
 	struct thread
 	{
 		int tid;               /**< Thread ID.              */
+		int coreid;            /**< Core ID.                */
 		int state;             /**< State.                  */
 		void *arg;             /**< Argument.               */
 		void *(*start)(void*); /**< Starting routine.       */
@@ -112,10 +113,14 @@
 	 * @returns A pointer to the thread that is running in the
 	 * underlying core.
 	 */
+	#if CLUSTER_IS_MULTICORE
+	EXTERN struct thread *thread_get_curr(void);
+	#else
 	static inline struct thread *thread_get_curr(void)
 	{
-		return (&threads[core_get_id()]);
+		return (KTHREAD_MASTER);
 	}
+	#endif
 
 	/**
 	 * @brief Gets the core ID of a thread.
@@ -129,7 +134,7 @@
 	 */
 	static inline int thread_get_coreid(const struct thread *t)
 	{
-		return (t - threads);
+		return (t->coreid);
 	}
 
 	/**

--- a/src/kernel/pm/thread.c
+++ b/src/kernel/pm/thread.c
@@ -69,6 +69,38 @@ PRIVATE int next_tid = (KTHREAD_MASTER_TID + 1);
 PRIVATE spinlock_t lock_tm = SPINLOCK_UNLOCKED;
 
 /*============================================================================*
+ * thread_get_curr()                                                          *
+ *============================================================================*/
+
+/**
+* @brief Gets the currently running thread.
+*
+* The thread_get() function returns a pointer to the thread
+* that is running in the underlying core.
+*
+* @returns A pointer to the thread that is running in the
+* underlying core.
+*/
+PUBLIC struct thread *thread_get_curr(void)
+{
+	int mycoreid; /* Core ID. */
+
+	mycoreid = core_get_id();
+
+	for (int i = 0; i < KTHREAD_MAX; i++)
+	{
+		/* Found. */
+		if (threads[i].coreid == mycoreid)
+		{
+			return (&threads[i]);
+		}
+	}
+
+	/* Should not happen. */
+	return (NULL);
+}
+
+/*============================================================================*
  * thread_alloc()                                                             *
  *============================================================================*/
 
@@ -95,6 +127,7 @@ PRIVATE struct thread *thread_alloc(void)
 		{
 			struct thread *new_thread;
 			new_thread = &threads[i];
+			new_thread->coreid = i;
 			new_thread->state = THREAD_STARTED;
 			nthreads++;
 


### PR DESCRIPTION
# Description

This P.R. aims to introduce kernel thread indexing without relying on core IDs.

# Related Issue

- [[tm] Kernel Thread Number](https://github.com/nanvix/microkernel/issues/125)