### PR TITLE
Docker Make Rules

### DIFF
--- a/build/makefile.run
+++ b/build/makefile.run
@@ -22,6 +22,8 @@
 # SOFTWARE.
 #
 
+ifeq ($(DOCKER),no)
+
 # Runs Unit Tests in all clusters
 run:
 	bash $(TOOLSDIR)/nanvix-run.sh $(IMAGE) $(BINDIR) $(EXEC) $(TARGET) all --no-debug
@@ -57,3 +59,35 @@ debug-iocluster:
 # Runs Unit Tests in Compute Cluster in debug mode.
 debug-ccluster:
 	bash $(TOOLSDIR)/nanvix-run.sh $(IMAGE) $(BINDIR) $(EXEC) $(TARGET) ccluster --debug
+
+# Run Docker containers.
+else
+
+# Runs Unit Tests in all clusters
+run:
+	cd $(ROOTDIR)/docker && docker-compose -f run.yml up $(TARGET)
+
+# Runs Unit Tests in IO Cluster.
+run-iocluster:
+	cd $(ROOTDIR)/docker && docker-compose -f run-iocluster.yml up $(TARGET)
+
+# Runs Unit Tests in Compute Cluster.
+run-ccluster:
+	cd $(ROOTDIR)/docker && docker-compose -f run-ccluster.yml up $(TARGET)
+
+# Runs Unit Tests in Compute Cluster.
+test-ccluster:
+	cd $(ROOTDIR)/docker && docker-compose -f test-ccluster.yml up $(TARGET)
+
+# Runs Unit Tests in all clusters in debug mode.
+debug:
+	cd $(ROOTDIR)/docker && docker-compose -f debug.yml up $(TARGET)
+
+# Runs Unit Tests in IO Cluster in debug mode.
+debug-iocluster:
+	cd $(ROOTDIR)/docker && docker-compose -f debug-iocluster.yml up $(TARGET)
+
+# Runs Unit Tests in Compute Cluster in debug mode.
+debug-ccluster:
+	cd $(ROOTDIR)/docker && docker-compose -f debug-ccluster.yml up $(TARGET)
+endif

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,22 @@
+# Ports.
+OPENRISC_PORT=4567
+RISCV32_PORT=4568
+X86_PORT=4569
+OPTIMSOC_PORT=4570
+
+# Container port.
+CONTAINER_PORT=4567
+
+# Bind mount source path.
+MNT_SRC=./..
+
+# Bind mount destination path.
+MNT_DST=/mnt
+
+# Docker images.
+OPENRISC_IMG=nanvix/ubuntu:qemu-openrisc
+RISCV32_IMG=nanvix/ubuntu:qemu-riscv32
+X86_IMG=nanvix/ubuntu:qemu-x86
+
+# OpTiMSoC target.
+OPTIMSOC_TARGET=optimsoc

--- a/docker/clean.yml
+++ b/docker/clean.yml
@@ -1,0 +1,61 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+version: '3'
+
+services:
+
+    qemu-openrisc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPENRISC_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make clean"
+
+    qemu-riscv32:
+      image: ${RISCV32_IMG}
+      ports:
+        - ${RISCV32_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && make clean"
+
+    qemu-x86:
+      image: ${X86_IMG}
+      ports:
+        - ${X86_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make clean"
+
+    optimsoc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPTIMSOC_PORT}:${CONTAINER_PORT}
+      environment:
+        - TARGET=${OPTIMSOC_TARGET}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make clean"

--- a/docker/debug-ccluster.yml
+++ b/docker/debug-ccluster.yml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+version: '3'
+
+services:
+
+    qemu-openrisc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPENRISC_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make debug-ccluster"
+      privileged: true
+      tty: true
+
+    qemu-riscv32:
+      image: ${RISCV32_IMG}
+      ports:
+        - ${RISCV32_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && make debug-ccluster"
+
+    qemu-x86:
+      image: ${X86_IMG}
+      ports:
+        - ${X86_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make debug-ccluster"
+      privileged: true
+      tty: true
+
+    optimsoc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPTIMSOC_PORT}:${CONTAINER_PORT}
+      environment:
+        - TARGET=${OPTIMSOC_TARGET}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make debug-ccluster"
+      privileged: true
+      tty: true

--- a/docker/debug-iocluster.yml
+++ b/docker/debug-iocluster.yml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+version: '3'
+
+services:
+
+    qemu-openrisc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPENRISC_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make debug-iocluster"
+      privileged: true
+      tty: true
+
+    qemu-riscv32:
+      image: ${RISCV32_IMG}
+      ports:
+        - ${RISCV32_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && make debug-iocluster"
+
+    qemu-x86:
+      image: ${X86_IMG}
+      ports:
+        - ${X86_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make debug-iocluster"
+      privileged: true
+      tty: true
+
+    optimsoc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPTIMSOC_PORT}:${CONTAINER_PORT}
+      environment:
+        - TARGET=${OPTIMSOC_TARGET}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make debug-iocluster"
+      privileged: true
+      tty: true

--- a/docker/debug.yml
+++ b/docker/debug.yml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+version: '3'
+
+services:
+
+    qemu-openrisc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPENRISC_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make debug"
+      privileged: true
+      tty: true
+
+    qemu-riscv32:
+      image: ${RISCV32_IMG}
+      ports:
+        - ${RISCV32_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && make debug"
+
+    qemu-x86:
+      image: ${X86_IMG}
+      ports:
+        - ${X86_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make debug"
+      privileged: true
+      tty: true
+
+    optimsoc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPTIMSOC_PORT}:${CONTAINER_PORT}
+      environment:
+        - TARGET=${OPTIMSOC_TARGET}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make debug"
+      privileged: true
+      tty: true

--- a/docker/distclean.yml
+++ b/docker/distclean.yml
@@ -1,0 +1,61 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+version: '3'
+
+services:
+
+    qemu-openrisc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPENRISC_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make distclean"
+
+    qemu-riscv32:
+      image: ${RISCV32_IMG}
+      ports:
+        - ${RISCV32_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && make distclean"
+
+    qemu-x86:
+      image: ${X86_IMG}
+      ports:
+        - ${X86_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make distclean"
+
+    optimsoc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPTIMSOC_PORT}:${CONTAINER_PORT}
+      environment:
+        - TARGET=${OPTIMSOC_TARGET}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make distclean"

--- a/docker/image-tests.yml
+++ b/docker/image-tests.yml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+version: '3'
+
+services:
+
+    qemu-openrisc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPENRISC_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make all"
+      privileged: true
+      tty: true
+
+    qemu-riscv32:
+      image: ${RISCV32_IMG}
+      ports:
+        - ${RISCV32_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && make all"
+
+    qemu-x86:
+      image: ${X86_IMG}
+      ports:
+        - ${X86_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make all"
+      privileged: true
+      tty: true
+
+    optimsoc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPTIMSOC_PORT}:${CONTAINER_PORT}
+      environment:
+        - TARGET=${OPTIMSOC_TARGET}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make all"
+      privileged: true
+      tty: true

--- a/docker/run-ccluster.yml
+++ b/docker/run-ccluster.yml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+version: '3'
+
+services:
+
+    qemu-openrisc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPENRISC_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make run-ccluster"
+      privileged: true
+      tty: true
+
+    qemu-riscv32:
+      image: ${RISCV32_IMG}
+      ports:
+        - ${RISCV32_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && make run-ccluster"
+
+    qemu-x86:
+      image: ${X86_IMG}
+      ports:
+        - ${X86_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make run-ccluster"
+      privileged: true
+      tty: true
+
+    optimsoc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPTIMSOC_PORT}:${CONTAINER_PORT}
+      environment:
+        - TARGET=${OPTIMSOC_TARGET}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make run-ccluster"
+      privileged: true
+      tty: true

--- a/docker/run-iocluster.yml
+++ b/docker/run-iocluster.yml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+version: '3'
+
+services:
+
+    qemu-openrisc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPENRISC_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make run-iocluster"
+      privileged: true
+      tty: true
+
+    qemu-riscv32:
+      image: ${RISCV32_IMG}
+      ports:
+        - ${RISCV32_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && make run-iocluster"
+
+    qemu-x86:
+      image: ${X86_IMG}
+      ports:
+        - ${X86_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make run-iocluster"
+      privileged: true
+      tty: true
+
+    optimsoc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPTIMSOC_PORT}:${CONTAINER_PORT}
+      environment:
+        - TARGET=${OPTIMSOC_TARGET}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make run-iocluster"
+      privileged: true
+      tty: true

--- a/docker/run.yml
+++ b/docker/run.yml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+version: '3'
+
+services:
+
+    qemu-openrisc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPENRISC_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make run"
+      privileged: true
+      tty: true
+
+    qemu-riscv32:
+      image: ${RISCV32_IMG}
+      ports:
+        - ${RISCV32_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && make run"
+
+    qemu-x86:
+      image: ${X86_IMG}
+      ports:
+        - ${X86_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make run"
+      privileged: true
+      tty: true
+
+    optimsoc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPTIMSOC_PORT}:${CONTAINER_PORT}
+      environment:
+        - TARGET=${OPTIMSOC_TARGET}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make run"
+      privileged: true
+      tty: true

--- a/docker/test-ccluster.yml
+++ b/docker/test-ccluster.yml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# Copyright(c) 2018 Pedro Henrique Penna <pedrohenriquepenna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+version: '3'
+
+services:
+
+    qemu-openrisc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPENRISC_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make test-ccluster"
+      privileged: true
+      tty: true
+
+    qemu-riscv32:
+      image: ${RISCV32_IMG}
+      ports:
+        - ${RISCV32_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && make test-ccluster"
+
+    qemu-x86:
+      image: ${X86_IMG}
+      ports:
+        - ${X86_PORT}:${CONTAINER_PORT}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make test-ccluster"
+      privileged: true
+      tty: true
+
+    optimsoc:
+      image: ${OPENRISC_IMG}
+      ports:
+        - ${OPTIMSOC_PORT}:${CONTAINER_PORT}
+      environment:
+        - TARGET=${OPTIMSOC_TARGET}
+      volumes:
+        - ${MNT_SRC}:${MNT_DST}
+      command: /bin/bash -l -c "cd ${MNT_DST} && bash ./utils/nanvix-setup-network.sh on --root && make test-ccluster"
+      privileged: true
+      tty: true


### PR DESCRIPTION
# Description

This P.R. aims to introduce new Make rules relying on Docker Compose to leverage Nanvix Docker images.

# Prerequisites
* Docker Compose is required.

# Usage
* Set the `DOCKER` environment variable to use Docker rules.
* If no target is specified then all targets will be processed. Several targets can be specified using the `TARGET` environment variable as usual (e.g. `export TARGET="qemu-riscv32 qemu-x86"`).

# Related Issue
* [Docker Make Rules](https://github.com/nanvix/microkernel/issues/159)