### PR TITLE
[tests] Drop Regression Tests in Installation

### DIFF
--- a/build/makefile.cflags
+++ b/build/makefile.cflags
@@ -39,3 +39,10 @@ else
 	export CFLAGS += -g
 
 endif
+
+ifeq ($(SUPPRESS_TESTS), true)
+
+	# Turn Off Regression tests
+	export CFLAGS += -D __SUPPRESS_TESTS
+
+endif

--- a/makefile
+++ b/makefile
@@ -35,6 +35,9 @@ export VERBOSE ?= no
 # Release Version?
 export RELEASE ?= no
 
+# Stall regression tests?
+export SUPPRESS_TESTS ?= no
+
 # Installation Prefix
 export PREFIX ?= $(HOME)
 
@@ -88,7 +91,7 @@ export CFLAGS  += -fno-stack-protector
 export CFLAGS  += -Wvla # -Wredundant-decls
 export CFLAGS  += -D__NANVIX_MICROKERNEL
 export CFLAGS  += -I $(INCDIR)
-export CFLAGS += -I $(ROOTDIR)/src/lwip/src/include
+export CFLAGS  += -I $(ROOTDIR)/src/lwip/src/include
 
 # Additional C Flags
 include $(BUILDDIR)/makefile.cflags

--- a/src/kernel/mm/frame.c
+++ b/src/kernel/mm/frame.c
@@ -118,7 +118,9 @@ PUBLIC void frame_init(void)
 #endif
 
 #ifndef NDEBUG
-	kprintf("[kernel][mm] running tests on the page frame allocator");
-	frame_test_driver();
+	#ifndef __SUPPRESS_TESTS
+		kprintf("[kernel][mm] running tests on the page frame allocator");
+		frame_test_driver();
+	#endif
 #endif
 }

--- a/src/kernel/mm/kpool.c
+++ b/src/kernel/mm/kpool.c
@@ -140,7 +140,9 @@ PUBLIC void kpool_init(void)
 #endif
 
 #ifndef NDEBUG
-	kprintf("[kernel][mm] running tests on the kernel page allocator");
-	kpool_test_driver();
+	#ifndef __SUPPRESS_TESTS
+		kprintf("[kernel][mm] running tests on the kernel page allocator");
+		kpool_test_driver();
+	#endif
 #endif
 }

--- a/src/kernel/mm/page.c
+++ b/src/kernel/mm/page.c
@@ -580,7 +580,9 @@ PUBLIC void upool_init(void)
 #endif
 
 #ifndef NDEBUG
-	kprintf("[kernel][mm] running tests on the user page allocator");
-	upool_test_driver();
+	#ifndef __SUPPRESS_TESTS
+		kprintf("[kernel][mm] running tests on the user page allocator");
+		upool_test_driver();
+	#endif
 #endif
 }


### PR DESCRIPTION
# **Description**
In this PR, there is the possibility to disable regression tests when building an installation from the above layers, using the makefile variable `SUPPRESS_TESTS = true`.

# **Related Issues**
[[tests] Drop Regression Tests in Installation #181](https://github.com/nanvix/microkernel/issues/181)