### PR TITLE
[kcall] Check for Parameters on NoC Facilities

### DIFF
--- a/include/nanvix/kernel/portal.h
+++ b/include/nanvix/kernel/portal.h
@@ -134,14 +134,14 @@
 	/**
 	 * @brief Performs control operations in a portal.
 	 *
-	 * @param mbxid   Target portal.
-	 * @param request Request.
-	 * @param args    Additional arguments.
+	 * @param portalid Target portal.
+	 * @param request  Request.
+	 * @param args     Additional arguments.
 	 *
 	 * @param Upon successful completion, zero is returned. Upon failure,
 	 * a negative error code is returned instead.
 	 */
-	EXTERN int do_portal_ioctl(int mbxid, unsigned request, va_list args);
+	EXTERN int do_portal_ioctl(int portalid, unsigned request, va_list args);
 
 #endif /* NANVIX_PORTAL_H_ */
 

--- a/src/kernel/noc/mailbox.c
+++ b/src/kernel/noc/mailbox.c
@@ -122,10 +122,6 @@ PUBLIC int do_mailbox_create(int local)
 {
 	int mbxid; /* Mailbox ID. */
 
-	/* Invalid local ID. */
-	if (!WITHIN(local, 0, PROCESSOR_NOC_NODES_NUM))
-		return (-EINVAL);
-
 	/* Searchs for existing mailboxes. */
 	for (int i = 0; i < (MAILBOX_CREATE_MAX + MAILBOX_OPEN_MAX); ++i)
 	{
@@ -199,10 +195,6 @@ PRIVATE int _do_mailbox_open(int remote)
 PUBLIC int do_mailbox_open(int remote)
 {
 	int mbxid; /* Mailbox ID. */
-
-	/* Invalid remote ID. */
-	if (!WITHIN(remote, 0, PROCESSOR_NOC_NODES_NUM))
-		return (-EINVAL);
 
 	/* Searchs for existing mailboxes. */
 	for (int i = 0; i < (MAILBOX_CREATE_MAX + MAILBOX_OPEN_MAX); ++i)
@@ -328,14 +320,6 @@ PUBLIC int do_mailbox_aread(int mbxid, void * buffer, size_t size)
 	if (!do_mailbox_is_valid(mbxid))
 		return (-EBADF);
 
-	/* Invalid buffer. */
-	if (buffer == NULL)
-		return (-EINVAL);
-
-	/* Invalid read size. */
-	if (size != MAILBOX_MSG_SIZE)
-		return (-EINVAL);
-
 	/* Bad mailbox. */
 	if (!resource_is_used(&mbxtab[mbxid].resource))
 		return (-EBADF);
@@ -377,14 +361,6 @@ PUBLIC int do_mailbox_awrite(int mbxid, const void * buffer, size_t size)
 	/* Invalid mailbox. */
 	if (!do_mailbox_is_valid(mbxid))
 		return (-EBADF);
-
-	/* Invalid buffer. */
-	if (buffer == NULL)
-		return (-EINVAL);
-
-	/* Invalid write size. */
-	if (size != MAILBOX_MSG_SIZE)
-		return (-EINVAL);
 
 	/* Bad mailbox. */
 	if (!resource_is_used(&mbxtab[mbxid].resource))

--- a/src/kernel/noc/portal.c
+++ b/src/kernel/noc/portal.c
@@ -127,10 +127,6 @@ PUBLIC int do_portal_create(int local)
 {
 	int portalid; /* Portal ID. */
 
-	/* Invalid local ID. */
-	if (!WITHIN(local, 0, PROCESSOR_NOC_NODES_NUM))
-		return (-EINVAL);
-
 	/* Searchs for existing portals. */
 	for (int i = 0; i < (PORTAL_CREATE_MAX + PORTAL_OPEN_MAX); ++i)
 	{
@@ -176,10 +172,6 @@ PUBLIC int do_portal_allow(int portalid, int remote)
 
 	if (!do_portal_is_valid(portalid))
 		return (-EBADF);
-
-	/* Invalid remote ID. */
-	if (!WITHIN(remote, 0, PROCESSOR_NOC_NODES_NUM))
-		return (-EINVAL);
 
 	/* Bad portal. */
 	if (!resource_is_used(&portaltab[portalid].resource))
@@ -244,14 +236,6 @@ PRIVATE int _do_portal_open(int local, int remote)
 PUBLIC int do_portal_open(int local, int remote)
 {
 	int portalid; /* Portal ID. */
-
-	/* Invalid local ID. */
-	if (!WITHIN(local, 0, PROCESSOR_NOC_NODES_NUM))
-		return (-EINVAL);
-
-	/* Invalid remote ID. */
-	if (!WITHIN(remote, 0, PROCESSOR_NOC_NODES_NUM))
-		return (-EINVAL);
 
 	/* Searchs for existing portals. */
 	for (int i = 0; i < (PORTAL_CREATE_MAX + PORTAL_OPEN_MAX); ++i)
@@ -388,14 +372,6 @@ PUBLIC int do_portal_aread(int portalid, void * buffer, size_t size)
 	if (!do_portal_is_valid(portalid))
 		return (-EBADF);
 
-	/* Invalid buffer. */
-	if (buffer == NULL)
-		return (-EINVAL);
-
-	/* Invalid read size. */
-	if (size == 0 || size > PORTAL_MAX_SIZE)
-		return (-EINVAL);
-
 	/* Bad portal. */
 	if (!resource_is_used(&portaltab[portalid].resource))
 		return (-EBADF);
@@ -437,14 +413,6 @@ PUBLIC int do_portal_awrite(int portalid, const void * buffer, size_t size)
 	/* Invalid portal. */
 	if (!do_portal_is_valid(portalid))
 		return (-EBADF);
-
-	/* Invalid buffer. */
-	if (buffer == NULL)
-		return (-EINVAL);
-
-	/* Invalid write size. */
-	if (size == 0 || size > PORTAL_MAX_SIZE)
-		return (-EINVAL);
 
 	/* Bad portal. */
 	if (!resource_is_used(&portaltab[portalid].resource))

--- a/src/kernel/noc/sync.c
+++ b/src/kernel/noc/sync.c
@@ -125,15 +125,6 @@ PUBLIC int do_sync_create(const int *nodes, int nnodes, int type)
 	int syncid;         /* Synchronization point.  */
 	uint64_t footprint; /* Target nodes footprint. */
 
-	if (nodes == NULL)
-		return (-EINVAL);
-
-	if (!WITHIN(nnodes, 2, (PROCESSOR_NOC_NODES_NUM + 1)))
-		return(-EINVAL);
-
-	if (type != SYNC_ONE_TO_ALL && type != SYNC_ALL_TO_ONE)
-		return (-EINVAL);
-
 	footprint = 0ULL;
 	for (int j = 0; j < nnodes; j++)
 		footprint |= (1ULL << nodes[j]);
@@ -228,15 +219,6 @@ PUBLIC int do_sync_open(const int *nodes, int nnodes, int type)
 {
 	int syncid;         /* Synchronization point.  */
 	uint64_t footprint; /* Target nodes footprint. */
-
-	if (nodes == NULL)
-		return (-EINVAL);
-
-	if (!WITHIN(nnodes, 2, (PROCESSOR_NOC_NODES_NUM + 1)))
-		return(-EINVAL);
-
-	if (type != SYNC_ONE_TO_ALL && type != SYNC_ALL_TO_ONE)
-		return (-EINVAL);
 
 	footprint = 0ULL;
 	for (int j = 0; j < nnodes; j++)

--- a/src/kernel/sys/mailbox.c
+++ b/src/kernel/sys/mailbox.c
@@ -24,6 +24,7 @@
 
 #include <nanvix/hal/hal.h>
 #include <nanvix/kernel/mailbox.h>
+#include <nanvix/kernel/mm.h>
 #include <posix/stdarg.h>
 
 #if __TARGET_HAS_MAILBOX
@@ -98,8 +99,6 @@ PUBLIC int kernel_mailbox_close(int mbxid)
 
 /**
  * @see do_mailbox_awrite().
- *
- * @todo TODO: Check buffer pointer if it is valid.
  */
 PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
 {
@@ -115,6 +114,10 @@ PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
 	if (buffer == NULL)
 		return (-EINVAL);
 
+	/* Bad buffer location. */
+	if (!mm_check_area(VADDR(buffer), size, UMEM_AREA))
+		return (-EFAULT);
+
 	return (do_mailbox_awrite(mbxid, buffer, size));
 }
 
@@ -124,8 +127,6 @@ PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
 
 /**
  * @see do_mailbox_aread().
- *
- * @todo TODO: Check buffer pointer if it is valid.
  */
 PUBLIC int kernel_mailbox_aread(int mbxid, void *buffer, size_t size)
 {
@@ -140,6 +141,10 @@ PUBLIC int kernel_mailbox_aread(int mbxid, void *buffer, size_t size)
 	/* Invalid buffer. */
 	if (buffer == NULL)
 		return (-EINVAL);
+
+	/* Bad buffer location. */
+	if (!mm_check_area(VADDR(buffer), size, UMEM_AREA))
+		return (-EFAULT);
 
 	return (do_mailbox_aread(mbxid, buffer, size));
 }
@@ -173,6 +178,10 @@ PUBLIC int kernel_mailbox_ioctl(int mbxid, unsigned request, va_list *args)
 
 	/* Invalid mailbox ID. */
 	if (mbxid < 0)
+		return (-EINVAL);
+
+	/* Bad args. */
+	if (args == NULL)
 		return (-EINVAL);
 
 	dcache_invalidate();

--- a/src/kernel/sys/mailbox.c
+++ b/src/kernel/sys/mailbox.c
@@ -37,6 +37,10 @@
  */
 PUBLIC int kernel_mailbox_create(int local)
 {
+	/* Invalid local ID. */
+	if (!WITHIN(local, 0, PROCESSOR_NOC_NODES_NUM))
+		return (-EINVAL);
+
 	return (do_mailbox_create(local));
 }
 
@@ -49,6 +53,10 @@ PUBLIC int kernel_mailbox_create(int local)
  */
 PUBLIC int kernel_mailbox_open(int remote)
 {
+	/* Invalid remote ID. */
+	if (!WITHIN(remote, 0, PROCESSOR_NOC_NODES_NUM))
+		return (-EINVAL);
+
 	return (do_mailbox_open(remote));
 }
 
@@ -61,6 +69,10 @@ PUBLIC int kernel_mailbox_open(int remote)
  */
 PUBLIC int kernel_mailbox_unlink(int mbxid)
 {
+	/* Invalid mailbox ID. */
+	if (mbxid < 0)
+		return (-EINVAL);
+
 	return (do_mailbox_unlink(mbxid));
 }
 
@@ -73,6 +85,10 @@ PUBLIC int kernel_mailbox_unlink(int mbxid)
  */
 PUBLIC int kernel_mailbox_close(int mbxid)
 {
+	/* Invalid mailbox ID. */
+	if (mbxid < 0)
+		return (-EINVAL);
+
 	return (do_mailbox_close(mbxid));
 }
 
@@ -82,9 +98,23 @@ PUBLIC int kernel_mailbox_close(int mbxid)
 
 /**
  * @see do_mailbox_awrite().
+ *
+ * @todo TODO: Check buffer pointer if it is valid.
  */
 PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
 {
+	/* Invalid mailbox ID. */
+	if (mbxid < 0)
+		return (-EINVAL);
+
+	/* Invalid write size. */
+	if (size != MAILBOX_MSG_SIZE)
+		return (-EINVAL);
+
+	/* Invalid buffer. */
+	if (buffer == NULL)
+		return (-EINVAL);
+
 	return (do_mailbox_awrite(mbxid, buffer, size));
 }
 
@@ -94,9 +124,23 @@ PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
 
 /**
  * @see do_mailbox_aread().
+ *
+ * @todo TODO: Check buffer pointer if it is valid.
  */
 PUBLIC int kernel_mailbox_aread(int mbxid, void *buffer, size_t size)
 {
+	/* Invalid mailbox ID. */
+	if (mbxid < 0)
+		return (-EINVAL);
+
+	/* Invalid read size. */
+	if (size != MAILBOX_MSG_SIZE)
+		return (-EINVAL);
+
+	/* Invalid buffer. */
+	if (buffer == NULL)
+		return (-EINVAL);
+
 	return (do_mailbox_aread(mbxid, buffer, size));
 }
 
@@ -109,6 +153,10 @@ PUBLIC int kernel_mailbox_aread(int mbxid, void *buffer, size_t size)
  */
 PUBLIC int kernel_mailbox_wait(int mbxid)
 {
+	/* Invalid mailbox ID. */
+	if (mbxid < 0)
+		return (-EINVAL);
+
 	return (do_mailbox_wait(mbxid));
 }
 
@@ -122,6 +170,10 @@ PUBLIC int kernel_mailbox_wait(int mbxid)
 PUBLIC int kernel_mailbox_ioctl(int mbxid, unsigned request, va_list *args)
 {
 	int ret;
+
+	/* Invalid mailbox ID. */
+	if (mbxid < 0)
+		return (-EINVAL);
 
 	dcache_invalidate();
 		ret = do_mailbox_ioctl(mbxid, request, *args);

--- a/src/kernel/sys/portal.c
+++ b/src/kernel/sys/portal.c
@@ -25,6 +25,7 @@
 
 #include <nanvix/hal/hal.h>
 #include <nanvix/kernel/portal.h>
+#include <nanvix/kernel/mm.h>
 #include <posix/stdarg.h>
 
 #if __TARGET_HAS_PORTAL
@@ -123,8 +124,6 @@ PUBLIC int kernel_portal_close(int portalid)
 
 /**
  * @see do_portal_awrite().
- *
- * @todo TODO: Check if buffer points to a valid memory region.
  */
 PUBLIC int kernel_portal_awrite(int portalid, const void * buffer, size_t size)
 {
@@ -140,6 +139,10 @@ PUBLIC int kernel_portal_awrite(int portalid, const void * buffer, size_t size)
 	if (buffer == NULL)
 		return (-EINVAL);
 
+	/* Bad buffer location. */
+	if (!mm_check_area(VADDR(buffer), size, UMEM_AREA))
+		return (-EFAULT);
+
 	return (do_portal_awrite(portalid, buffer, size));
 }
 
@@ -149,8 +152,6 @@ PUBLIC int kernel_portal_awrite(int portalid, const void * buffer, size_t size)
 
 /**
  * @see do_portal_aread().
- *
- * @todo TODO: Check if buffer points to a valid memory region.
  */
 PUBLIC int kernel_portal_aread(int portalid, void * buffer, size_t size)
 {
@@ -165,6 +166,10 @@ PUBLIC int kernel_portal_aread(int portalid, void * buffer, size_t size)
 	/* Invalid buffer. */
 	if (buffer == NULL)
 		return (-EINVAL);
+
+	/* Bad buffer location. */
+	if (!mm_check_area(VADDR(buffer), size, UMEM_AREA))
+		return (-EFAULT);
 
 	return (do_portal_aread(portalid, buffer, size));
 }
@@ -198,6 +203,10 @@ PUBLIC int kernel_portal_ioctl(int portalid, unsigned request, va_list *args)
 
 	/* Invalid portal ID. */
 	if (portalid < 0)
+		return (-EINVAL);
+
+	/* Bad args. */
+	if (args == NULL)
 		return (-EINVAL);
 
 	dcache_invalidate();

--- a/src/kernel/sys/portal.c
+++ b/src/kernel/sys/portal.c
@@ -38,6 +38,10 @@
  */
 PUBLIC int kernel_portal_create(int local)
 {
+	/* Invalid local ID. */
+	if (!WITHIN(local, 0, PROCESSOR_NOC_NODES_NUM))
+		return (-EINVAL);
+
 	return (do_portal_create(local));
 }
 
@@ -50,6 +54,14 @@ PUBLIC int kernel_portal_create(int local)
  */
 PUBLIC int kernel_portal_allow(int portalid, int remote)
 {
+	/* Invalid portal ID. */
+	if (portalid < 0)
+		return (-EINVAL);
+
+	/* Invalid remote ID. */
+	if (!WITHIN(remote, 0, PROCESSOR_NOC_NODES_NUM))
+		return (-EINVAL);
+
 	return (do_portal_allow(portalid, remote));
 }
 
@@ -62,6 +74,14 @@ PUBLIC int kernel_portal_allow(int portalid, int remote)
  */
 PUBLIC int kernel_portal_open(int local, int remote)
 {
+	/* Invalid local ID. */
+	if (!WITHIN(local, 0, PROCESSOR_NOC_NODES_NUM))
+		return (-EINVAL);
+
+	/* Invalid remote ID. */
+	if (!WITHIN(remote, 0, PROCESSOR_NOC_NODES_NUM))
+		return (-EINVAL);
+
 	return (do_portal_open(local, remote));
 }
 
@@ -74,6 +94,10 @@ PUBLIC int kernel_portal_open(int local, int remote)
  */
 PUBLIC int kernel_portal_unlink(int portalid)
 {
+	/* Invalid portal ID. */
+	if (portalid < 0)
+		return (-EINVAL);
+
 	return (do_portal_unlink(portalid));
 }
 
@@ -86,6 +110,10 @@ PUBLIC int kernel_portal_unlink(int portalid)
  */
 PUBLIC int kernel_portal_close(int portalid)
 {
+	/* Invalid portal ID. */
+	if (portalid < 0)
+		return (-EINVAL);
+
 	return (do_portal_close(portalid));
 }
 
@@ -95,9 +123,23 @@ PUBLIC int kernel_portal_close(int portalid)
 
 /**
  * @see do_portal_awrite().
+ *
+ * @todo TODO: Check if buffer points to a valid memory region.
  */
 PUBLIC int kernel_portal_awrite(int portalid, const void * buffer, size_t size)
 {
+	/* Invalid portal ID. */
+	if (portalid < 0)
+		return (-EINVAL);
+
+	/* Invalid buffer size. */
+	if (size <= 0 || size > PORTAL_MAX_SIZE)
+		return (-EINVAL);
+
+	/* Invalid buffer. */
+	if (buffer == NULL)
+		return (-EINVAL);
+
 	return (do_portal_awrite(portalid, buffer, size));
 }
 
@@ -107,9 +149,23 @@ PUBLIC int kernel_portal_awrite(int portalid, const void * buffer, size_t size)
 
 /**
  * @see do_portal_aread().
+ *
+ * @todo TODO: Check if buffer points to a valid memory region.
  */
 PUBLIC int kernel_portal_aread(int portalid, void * buffer, size_t size)
 {
+	/* Invalid portal ID. */
+	if (portalid < 0)
+		return (-EINVAL);
+
+	/* Invalid buffer size. */
+	if (size <= 0 || size > PORTAL_MAX_SIZE)
+		return (-EINVAL);
+
+	/* Invalid buffer. */
+	if (buffer == NULL)
+		return (-EINVAL);
+
 	return (do_portal_aread(portalid, buffer, size));
 }
 
@@ -122,6 +178,10 @@ PUBLIC int kernel_portal_aread(int portalid, void * buffer, size_t size)
  */
 PUBLIC int kernel_portal_wait(int portalid)
 {
+	/* Invalid portal ID. */
+	if (portalid < 0)
+		return (-EINVAL);
+
 	return (do_portal_wait(portalid));
 }
 
@@ -132,12 +192,16 @@ PUBLIC int kernel_portal_wait(int portalid)
 /**
  * @see do_portal_ioctl().
  */
-PUBLIC int kernel_portal_ioctl(int mbxid, unsigned request, va_list *args)
+PUBLIC int kernel_portal_ioctl(int portalid, unsigned request, va_list *args)
 {
 	int ret;
 
+	/* Invalid portal ID. */
+	if (portalid < 0)
+		return (-EINVAL);
+
 	dcache_invalidate();
-		ret = do_portal_ioctl(mbxid, request, *args);
+		ret = do_portal_ioctl(portalid, request, *args);
 	dcache_invalidate();
 
 	return (ret);

--- a/src/kernel/sys/sync.c
+++ b/src/kernel/sys/sync.c
@@ -46,8 +46,8 @@ PUBLIC int kernel_sync_create(const int *nodes, int nnodes, int type)
 		return (-EINVAL);
 
 	/* Invalid number of nodes. */
-	if (nnodes < 2)
-		return (-EINVAL);
+	if (!WITHIN(nnodes, 2, (PROCESSOR_NOC_NODES_NUM + 1)))
+		return(-EINVAL);
 
 	/* Bad nodes list. */
 	for (int i = 0; i < nnodes; i++)
@@ -81,8 +81,8 @@ PUBLIC int kernel_sync_open(const int *nodes, int nnodes, int type)
 		return (-EINVAL);
 
 	/* Invalid number of nodes. */
-	if (nnodes < 2)
-		return (-EINVAL);
+	if (!WITHIN(nnodes, 2, (PROCESSOR_NOC_NODES_NUM + 1)))
+		return(-EINVAL);
 
 	/* Bad nodes list. */
 	for (int i = 0; i < nnodes; i++)
@@ -94,6 +94,7 @@ PUBLIC int kernel_sync_open(const int *nodes, int nnodes, int type)
 	/* Bad sync type. */
 	if ((type != SYNC_ONE_TO_ALL) && (type != SYNC_ALL_TO_ONE))
 		return (-EINVAL);
+
 	return (do_sync_open(nodes, nnodes, type));
 }
 
@@ -106,6 +107,10 @@ PUBLIC int kernel_sync_open(const int *nodes, int nnodes, int type)
  */
 PUBLIC int kernel_sync_wait(int syncid)
 {
+	/* Invalid sync ID. */
+	if (syncid < 0)
+		return (-EINVAL);
+
 	return (do_sync_wait(syncid));
 }
 
@@ -118,6 +123,10 @@ PUBLIC int kernel_sync_wait(int syncid)
  */
 PUBLIC int kernel_sync_signal(int syncid)
 {
+	/* Invalid sync ID. */
+	if (syncid < 0)
+		return (-EINVAL);
+
 	return (do_sync_signal(syncid));
 }
 
@@ -130,6 +139,10 @@ PUBLIC int kernel_sync_signal(int syncid)
  */
 PUBLIC int kernel_sync_close(int syncid)
 {
+	/* Invalid sync ID. */
+	if (syncid < 0)
+		return (-EINVAL);
+
 	return (do_sync_close(syncid));
 }
 
@@ -142,6 +155,10 @@ PUBLIC int kernel_sync_close(int syncid)
  */
 PUBLIC int kernel_sync_unlink(int syncid)
 {
+	/* Invalid sync ID. */
+	if (syncid < 0)
+		return (-EINVAL);
+
 	return (do_sync_unlink(syncid));
 }
 

--- a/src/kernel/sys/sync.c
+++ b/src/kernel/sys/sync.c
@@ -24,6 +24,7 @@
 
 #include <nanvix/hal/hal.h>
 #include <nanvix/kernel/sync.h>
+#include <nanvix/kernel/mm.h>
 #include <posix/errno.h>
 
 #if __TARGET_HAS_SYNC
@@ -48,6 +49,10 @@ PUBLIC int kernel_sync_create(const int *nodes, int nnodes, int type)
 	/* Invalid number of nodes. */
 	if (!WITHIN(nnodes, 2, (PROCESSOR_NOC_NODES_NUM + 1)))
 		return(-EINVAL);
+
+	/* Bad nodes list location. */
+	if (!mm_check_area(VADDR(nodes), sizeof(int) * nnodes, UMEM_AREA))
+		return(-EFAULT);
 
 	/* Bad nodes list. */
 	for (int i = 0; i < nnodes; i++)
@@ -83,6 +88,10 @@ PUBLIC int kernel_sync_open(const int *nodes, int nnodes, int type)
 	/* Invalid number of nodes. */
 	if (!WITHIN(nnodes, 2, (PROCESSOR_NOC_NODES_NUM + 1)))
 		return(-EINVAL);
+
+	/* Bad nodes list location. */
+	if (!mm_check_area(VADDR(nodes), sizeof(int) * nnodes, UMEM_AREA))
+		return(-EFAULT);
 
 	/* Bad nodes list. */
 	for (int i = 0; i < nnodes; i++)

--- a/src/kernel/sys/write.c
+++ b/src/kernel/sys/write.c
@@ -25,6 +25,7 @@
 #include <nanvix/const.h>
 #include <nanvix/klib.h>
 #include <nanvix/hal/hal.h>
+#include <nanvix/kernel/mm.h>
 #include <stdint.h>
 
 /**
@@ -81,6 +82,10 @@ PUBLIC ssize_t kernel_write(int fd, const char *buf, size_t n)
 	/* Invalid buffer size. */
 	if (n > WRITE_BUFFER_SIZE)
 		return (-EINVAL);
+
+	/* Invalid buffer location. */
+	if (!mm_check_area(VADDR(buf), n, UMEM_AREA))
+		return (-EFAULT);
 
 	/* Avoid overflow. */
 	kmemcpy(buf2, buf, n);


### PR DESCRIPTION
# Description
In this PR was made the separation between logic and semantic related to the parameters checks on NoC facilities (Mailbox, Portal and Sync). Now, logic checks are in `kernel/sys`, while semantic still in `kernel/noc`. 
Also, checks for pointers validity were added to avoid bad memory accesses from the user space.

# Related Issues

- #191 - [[kcall] Check Mailbox Parameters](https://github.com/nanvix/microkernel/issues/191)
- #192 - [[kcall] Check Portal Parameters](https://github.com/nanvix/microkernel/issues/192)
- #194 - [[kcall] Check Sync Parameters](https://github.com/nanvix/microkernel/issues/194)
- #193 - [[kcall] Check for Pointers](https://github.com/nanvix/microkernel/issues/193)