### PR TITLE
Launching Init Thread with Two or More Cores

### DIFF
--- a/include/nanvix/kernel/syscall.h
+++ b/include/nanvix/kernel/syscall.h
@@ -91,6 +91,7 @@
 	#define NR_portal_wait    38 /**< kernel_portal_wait()    */
 	#define NR_portal_ioctl   39 /**< kernel_portal_ioctl()   */
 	#define NR_clock          40 /**< kernel_clock()          */
+	#define NR_stats          42 /**< kernel_stats()          */
 
 	#define NR_last_kcall     41 /**< NR_SYSCALLS definer     */
 	/**@}*/

--- a/src/kernel/init/main.c
+++ b/src/kernel/init/main.c
@@ -47,7 +47,7 @@ PRIVATE void *init(void *arg)
 
 	UNUSED(arg);
 
-#if (CORES_NUM > 2)
+#if (CORES_NUM >= 2)
 
 	___start(argc, argv, NULL);
 

--- a/src/kernel/sys/syscalls.c
+++ b/src/kernel/sys/syscalls.c
@@ -390,6 +390,12 @@ PUBLIC int do_kcall(
 			);
 			break;
 
+		case NR_stats:
+			perf_stop(1);
+			ret  = perf_read(1);
+			perf_start(1, arg0);
+			break;
+
 		/* Forward system call. */
 		default:
 		{

--- a/src/test/lwip/lwip_manual.c
+++ b/src/test/lwip/lwip_manual.c
@@ -29,8 +29,15 @@
 #include <lwip/tcp.h>
 #include <lwip/etharp.h>
 
+/**
+ * @brief Launch manual tests?
+ */
+#ifndef __TEST_LWIP_MANUAL
+#define __TEST_LWIP_MANUAL 0
+#endif
+
 /*============================================================================*
- * Utils function	                                                 		  *
+ * Utils Functions                                                            *
  *============================================================================*/
 
 /**
@@ -82,7 +89,7 @@ static void print_payload(struct pbuf* p)
 }
 
 /*============================================================================*
- * UDP Manual Tests	                                                 		  *
+ * UDP Manual Tests                                                           *
  *============================================================================*/
 
 static const char *udp_data = "this is a udp packet";
@@ -121,6 +128,10 @@ static void udp_echo_recv(
  */
 PUBLIC void test_lwip_udp_send_receive_manual(struct netif* netif)
 {
+#if !(__TEST_LWIP_MANUAL)
+	return;
+#endif
+
 	etharp_add_static_entry(&netif->ip_addr, (struct eth_addr *)(&netif->hwaddr));
 
 	udp_recv_counter = 0;
@@ -152,7 +163,7 @@ PUBLIC void test_lwip_udp_send_receive_manual(struct netif* netif)
 }
 
 /*============================================================================*
- * TCP Manual Tests	                                                 		  *
+ * TCP Manual Tests                                                           *
  *============================================================================*/
 
 static struct tcp_pcb *receiver_pcb;
@@ -203,6 +214,10 @@ static err_t receive_accept(void *arg, struct tcp_pcb *newpcb, err_t err)
  */
 PUBLIC void test_lwip_tcp_send_receive_manual(struct netif* netif)
 {
+#if !(__TEST_LWIP_MANUAL)
+	return;
+#endif
+
 	tcp_recv_counter = 0;
 
 	/* Init the tcp server pcb */


### PR DESCRIPTION
# Description

In order to start 'init' and consequently libnanvix, the architecture must have at least 2 cores, not three as it was before, so targets like qemu-openrisc can work without any problems.

# Related Issues

- [[tests] Set Network Tests as Manual](https://github.com/nanvix/microkernel/issues/209)