### PR TITLE
[ikc] Multiplex HW Mailboxes

### DIFF
--- a/include/nanvix/kernel/mailbox.h
+++ b/include/nanvix/kernel/mailbox.h
@@ -37,7 +37,7 @@
 	#include <posix/stdarg.h>
 
 	/**
-	 * @name Requests for do_mailbox_ioctl()
+	 * @name Requests for do_vmailbox_ioctl()
 	 */
 	/**@{*/
 	#define MAILBOX_IOCTL_GET_VOLUME  1 /**< Get the amount of data transferred so far. */
@@ -45,7 +45,14 @@
 	/**@}*/
 
 	/**
-	 * @brief Creates a mailbox.
+	 * @brief Maximum number of virtual mailboxes.
+	 *
+	 * Maximum number of virtual mailboxes that may be created/opened.
+	 */
+	#define KMAILBOX_MAX 1024
+
+	/**
+	 * @brief Creates a virtual mailbox.
 	 *
 	 * @param local Logic ID of the Local Node.
 	 *
@@ -53,10 +60,10 @@
 	 * mailbox is returned. Upon failure, a negative error code is
 	 * returned instead.
 	 */
-	EXTERN int do_mailbox_create(int local);
+	EXTERN int do_vmailbox_create(int local);
 
 	/**
-	 * @brief Opens a mailbox.
+	 * @brief Opens a virtual mailbox.
 	 *
 	 * @param remote Logic ID of the Target Node.
 	 *
@@ -64,64 +71,64 @@
 	 * is returned. Upon failure, a negative error code is returned
 	 * instead.
 	 */
-	EXTERN int do_mailbox_open(int remote);
+	EXTERN int do_vmailbox_open(int remote);
 
 	/**
-	 * @brief Destroys a mailbox.
+	 * @brief Destroys a virtual mailbox.
 	 *
-	 * @param mbxid ID of the Target Mailbox.
+	 * @param mbxid ID of the target virtual mailbox.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon failure,
 	 * a negative error code is returned instead.
 	 */
-	EXTERN int do_mailbox_unlink(int mbxid);
+	EXTERN int do_vmailbox_unlink(int mbxid);
 
 	/**
-	 * @brief Closes a mailbox.
+	 * @brief Closes a virtual mailbox.
 	 *
-	 * @param mbxid ID of the Target Mailbox.
+	 * @param mbxid ID of the target virtual mailbox.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN int do_mailbox_close(int mbxid);
+	EXTERN int do_vmailbox_close(int mbxid);
 
 	/**
-	 * @brief Reads data from a mailbox.
+	 * @brief Reads data from a virtual mailbox.
 	 *
-	 * @param mbxid  ID of the Target Mailbox.
+	 * @param mbxid  ID of the target virtual mailbox.
 	 * @param buffer Buffer where the data should be written to.
 	 * @param size   Number of bytes to read.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN int do_mailbox_aread(int mbxid, void * buffer, size_t size);
+	EXTERN int do_vmailbox_aread(int mbxid, void * buffer, size_t size);
 
 	/**
-	 * @brief Writes data to a mailbox.
+	 * @brief Writes data to a virtual mailbox.
 	 *
-	 * @param mbxid ID of the Target Mailbox.
+	 * @param mbxid ID of the target virtual mailbox.
 	 * @param buffer   Buffer where the data should be read from.
 	 * @param size     Number of bytes to write.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN int do_mailbox_awrite(int mbxid, const void * buffer, size_t size);
+	EXTERN int do_vmailbox_awrite(int mbxid, const void * buffer, size_t size);
 
 	/**
-	 * @brief Waits for an asynchronous operation on a mailbox to complete.
+	 * @brief Waits for an asynchronous operation on a virtual mailbox.
 	 *
-	 * @param mbxid ID of the Target Mailbox.
+	 * @param mbxid ID of the target virtual mailbox.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN int do_mailbox_wait(int mbxid);
+	EXTERN int do_vmailbox_wait(int mbxid);
 
 	/**
-	 * @brief Performs control operations in a mailbox.
+	 * @brief Performs control operations in a virtual mailbox.
 	 *
 	 * @param mbxid   Target mailbox.
 	 * @param request Request.
@@ -130,7 +137,7 @@
 	 * @param Upon successful completion, zero is returned. Upon failure,
 	 * a negative error code is returned instead.
 	 */
-	EXTERN int do_mailbox_ioctl(int mbxid, unsigned request, va_list args);
+	EXTERN int do_vmailbox_ioctl(int mbxid, unsigned request, va_list args);
 
 #endif /* NANVIX_MAILBOX_H_ */
 

--- a/src/kernel/sys/mailbox.c
+++ b/src/kernel/sys/mailbox.c
@@ -34,7 +34,7 @@
  *============================================================================*/
 
 /**
- * @see do_mailbox_create().
+ * @see do_vmailbox_create().
  */
 PUBLIC int kernel_mailbox_create(int local)
 {
@@ -42,7 +42,7 @@ PUBLIC int kernel_mailbox_create(int local)
 	if (!WITHIN(local, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
 
-	return (do_mailbox_create(local));
+	return (do_vmailbox_create(local));
 }
 
 /*============================================================================*
@@ -50,7 +50,7 @@ PUBLIC int kernel_mailbox_create(int local)
  *============================================================================*/
 
 /**
- * @see do_mailbox_open().
+ * @see do_vmailbox_open().
  */
 PUBLIC int kernel_mailbox_open(int remote)
 {
@@ -58,7 +58,7 @@ PUBLIC int kernel_mailbox_open(int remote)
 	if (!WITHIN(remote, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
 
-	return (do_mailbox_open(remote));
+	return (do_vmailbox_open(remote));
 }
 
 /*============================================================================*
@@ -66,7 +66,7 @@ PUBLIC int kernel_mailbox_open(int remote)
  *============================================================================*/
 
 /**
- * @see do_mailbox_unlink().
+ * @see do_vmailbox_unlink().
  */
 PUBLIC int kernel_mailbox_unlink(int mbxid)
 {
@@ -74,7 +74,7 @@ PUBLIC int kernel_mailbox_unlink(int mbxid)
 	if (mbxid < 0)
 		return (-EINVAL);
 
-	return (do_mailbox_unlink(mbxid));
+	return (do_vmailbox_unlink(mbxid));
 }
 
 /*============================================================================*
@@ -82,7 +82,7 @@ PUBLIC int kernel_mailbox_unlink(int mbxid)
  *============================================================================*/
 
 /**
- * @see do_mailbox_close().
+ * @see do_vmailbox_close().
  */
 PUBLIC int kernel_mailbox_close(int mbxid)
 {
@@ -90,7 +90,7 @@ PUBLIC int kernel_mailbox_close(int mbxid)
 	if (mbxid < 0)
 		return (-EINVAL);
 
-	return (do_mailbox_close(mbxid));
+	return (do_vmailbox_close(mbxid));
 }
 
 /*============================================================================*
@@ -98,7 +98,7 @@ PUBLIC int kernel_mailbox_close(int mbxid)
  *============================================================================*/
 
 /**
- * @see do_mailbox_awrite().
+ * @see do_vmailbox_awrite().
  */
 PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
 {
@@ -118,7 +118,7 @@ PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
 	if (!mm_check_area(VADDR(buffer), size, UMEM_AREA))
 		return (-EFAULT);
 
-	return (do_mailbox_awrite(mbxid, buffer, size));
+	return (do_vmailbox_awrite(mbxid, buffer, size));
 }
 
 /*============================================================================*
@@ -126,7 +126,7 @@ PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
  *============================================================================*/
 
 /**
- * @see do_mailbox_aread().
+ * @see do_vmailbox_aread().
  */
 PUBLIC int kernel_mailbox_aread(int mbxid, void *buffer, size_t size)
 {
@@ -146,7 +146,7 @@ PUBLIC int kernel_mailbox_aread(int mbxid, void *buffer, size_t size)
 	if (!mm_check_area(VADDR(buffer), size, UMEM_AREA))
 		return (-EFAULT);
 
-	return (do_mailbox_aread(mbxid, buffer, size));
+	return (do_vmailbox_aread(mbxid, buffer, size));
 }
 
 /*============================================================================*
@@ -154,7 +154,7 @@ PUBLIC int kernel_mailbox_aread(int mbxid, void *buffer, size_t size)
  *============================================================================*/
 
 /**
- * @see do_mailbox_wait().
+ * @see do_vmailbox_wait().
  */
 PUBLIC int kernel_mailbox_wait(int mbxid)
 {
@@ -162,7 +162,7 @@ PUBLIC int kernel_mailbox_wait(int mbxid)
 	if (mbxid < 0)
 		return (-EINVAL);
 
-	return (do_mailbox_wait(mbxid));
+	return (do_vmailbox_wait(mbxid));
 }
 
 /*============================================================================*
@@ -170,7 +170,7 @@ PUBLIC int kernel_mailbox_wait(int mbxid)
  *============================================================================*/
 
 /**
- * @see do_mailbox_ioctl().
+ * @see do_vmailbox_ioctl().
  */
 PUBLIC int kernel_mailbox_ioctl(int mbxid, unsigned request, va_list *args)
 {
@@ -185,7 +185,7 @@ PUBLIC int kernel_mailbox_ioctl(int mbxid, unsigned request, va_list *args)
 		return (-EINVAL);
 
 	dcache_invalidate();
-		ret = do_mailbox_ioctl(mbxid, request, *args);
+		ret = do_vmailbox_ioctl(mbxid, request, *args);
 	dcache_invalidate();
 
 	return (ret);


### PR DESCRIPTION
# Description
In this PR was added the support and multiplexing of virtual mailboxes. Now, the user can call multiple `open` and `create` calls, limited only by `VIRTUAL_MAILBOX_MAX` constant, that limits the number of virtual mailboxes that can be created. 

# Related issues
[ [ikc] Multiplex HW Mailboxes](https://github.com/nanvix/microkernel/issues/197)