### PR TITLE
[ikc] Multiplex HW Portals

### DIFF
--- a/include/nanvix/kernel/portal.h
+++ b/include/nanvix/kernel/portal.h
@@ -45,103 +45,111 @@
 	/**@}*/
 
 	/**
-	 * @brief Creates a portal.
+	 * @brief Maximum number of virtual portals.
+	 *
+	 * Maximum number of virtual portals that may be created/opened.
+	 */
+	#define KPORTAL_MAX 1024
+
+	/**
+	 * @brief Creates a virtual portal.
 	 *
 	 * @param local Logic ID of the Local Node.
 	 *
-	 * @returns Upon successful completion, the ID of a newly created
+	 * @returns Upon successful completion, the ID of a newly created virtual
 	 * portal is returned. Upon failure, a negative error code is returned
 	 * instead.
 	 */
-	EXTERN int do_portal_create(int local);
+	EXTERN int do_vportal_create(int local);
 
 	/**
 	 * @brief Enables read operations from a remote.
 	 *
-	 * @param portalid ID of the Target Portal.
+	 * @param portalid ID of the target virtual portal.
 	 * @param remote   Logic ID of Target Node.
 	 *
 	 * @returns Upons successful completion zero is returned. Upon failure,
 	 * a negative error code is returned instead.
 	 */
-	EXTERN int do_portal_allow(int portalid, int remote);
+	EXTERN int do_vportal_allow(int portalid, int remote);
 
 	/**
-	 * @brief Opens a portal.
+	 * @brief Opens a virtual portal.
 	 *
 	 * @param local  Logic ID of the local NoC node.
 	 * @param remote Logic ID of the target NoC node.
 	 *
-	 * @returns Upon successful completion, the ID of the target portal is
-	 * returned. Upon failure, a negative error code is returned instead.
+	 * @returns Upon successful completion, the ID of the target virtual
+	 * portal is returned. Upon failure, a negative error code is returned
+	 * instead.
 	 */
-	EXTERN int do_portal_open(int local, int remote);
+	EXTERN int do_vportal_open(int local, int remote);
 
 	/**
-	 * @brief Destroys a portal.
+	 * @brief Destroys a virtual portal.
 	 *
-	 * @param portalid ID of the Target Portal.
+	 * @param portalid ID of the target virtual portal.
 	 *
 	 * @returns Upon successful completion zero is returned. Upon failure, a
 	 * negative error code is returned instead.
 	 */
-	EXTERN int do_portal_unlink(int portalid);
+	EXTERN int do_vportal_unlink(int portalid);
 
 	/**
-	 * @brief Closes a portal.
+	 * @brief Closes a virtual portal.
 	 *
-	 * @param portalid ID of the Target Portal.
+	 * @param portalid ID of the target virtual portal.
 	 *
 	 * @returns Upon successful completion zero is returned. Upon failure, a
 	 * negative error code is returned instead.
 	 */
-	EXTERN int do_portal_close(int portalid);
+	EXTERN int do_vportal_close(int portalid);
 
 	/**
-	 * @brief Reads data asynchronously from a portal.
+	 * @brief Reads data asynchronously from a virtual portal.
 	 *
-	 * @param portalid ID of the Target Portal.
+	 * @param portalid ID of the target virtual portal.
 	 * @param buffer   Location from where data should be written.
 	 * @param size     Number of bytes to read.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN int do_portal_aread(int portalid, void * buffer, size_t size);
+	EXTERN int do_vportal_aread(int portalid, void * buffer, size_t size);
 
 	/**
-	* @brief Writes data asynchronously to a portal.
+	* @brief Writes data asynchronously to a virtual portal.
 	*
-	* @param portalid ID of the Target Portal.
+	* @param portalid ID of the target virtual portal.
 	* @param buffer   Location from where data should be read.
 	* @param size     Number of bytes to write.
 	*
 	* @returns Upon successful, zero is returned. Upon failure, a
 	* negative error code is returned instead.
 	*/
-	EXTERN int do_portal_awrite(int portalid, const void * buffer, size_t size);
+	EXTERN int do_vportal_awrite(int portalid, const void * buffer, size_t size);
 
 	/**
-	 * @brief Waits for an asynchronous operation on a portal to complete.
+	 * @brief Waits for an asynchronous operation on a virtual portal to complete.
 	 *
-	 * @param portalid ID of the Target Portal.
+	 * @param portalid ID of the target virtual portal.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN int do_portal_wait(int portalid);
+	EXTERN int do_vportal_wait(int portalid);
 
 	/**
-	 * @brief Performs control operations in a portal.
+	 * @brief Performs control operations in a virtual portal.
 	 *
-	 * @param portalid Target portal.
+	 * @param portalid Target virtual portal.
 	 * @param request  Request.
 	 * @param args     Additional arguments.
 	 *
 	 * @param Upon successful completion, zero is returned. Upon failure,
 	 * a negative error code is returned instead.
 	 */
-	EXTERN int do_portal_ioctl(int portalid, unsigned request, va_list args);
+	EXTERN int do_vportal_ioctl(int portalid, unsigned request, va_list args);
 
 #endif /* NANVIX_PORTAL_H_ */
 

--- a/src/kernel/noc/mailbox.c
+++ b/src/kernel/noc/mailbox.c
@@ -558,7 +558,7 @@ PUBLIC int do_vmailbox_wait(int mbxid)
 	t1 = clock_read();
 
 		/* Wait for asynchronous operation. */
-		ret = mailbox_wait(active_mailboxes[virtual_mailboxes[mbxid].fd].hwfd);
+		ret = mailbox_wait(active_mailboxes[fd].hwfd);
 
 	t2 = clock_read();
 

--- a/src/kernel/sys/portal.c
+++ b/src/kernel/sys/portal.c
@@ -35,7 +35,7 @@
  *============================================================================*/
 
 /**
- * @see do_portal_create().
+ * @see do_vportal_create().
  */
 PUBLIC int kernel_portal_create(int local)
 {
@@ -43,7 +43,7 @@ PUBLIC int kernel_portal_create(int local)
 	if (!WITHIN(local, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
 
-	return (do_portal_create(local));
+	return (do_vportal_create(local));
 }
 
 /*============================================================================*
@@ -51,7 +51,7 @@ PUBLIC int kernel_portal_create(int local)
  *============================================================================*/
 
 /**
- * @see do_portal_allow().
+ * @see do_vportal_allow().
  */
 PUBLIC int kernel_portal_allow(int portalid, int remote)
 {
@@ -63,7 +63,7 @@ PUBLIC int kernel_portal_allow(int portalid, int remote)
 	if (!WITHIN(remote, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
 
-	return (do_portal_allow(portalid, remote));
+	return (do_vportal_allow(portalid, remote));
 }
 
 /*============================================================================*
@@ -71,7 +71,7 @@ PUBLIC int kernel_portal_allow(int portalid, int remote)
  *============================================================================*/
 
 /**
- * @see do_portal_open().
+ * @see do_vportal_open().
  */
 PUBLIC int kernel_portal_open(int local, int remote)
 {
@@ -83,7 +83,7 @@ PUBLIC int kernel_portal_open(int local, int remote)
 	if (!WITHIN(remote, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
 
-	return (do_portal_open(local, remote));
+	return (do_vportal_open(local, remote));
 }
 
 /*============================================================================*
@@ -91,7 +91,7 @@ PUBLIC int kernel_portal_open(int local, int remote)
  *============================================================================*/
 
 /**
- * @see do_portal_unlink().
+ * @see do_vportal_unlink().
  */
 PUBLIC int kernel_portal_unlink(int portalid)
 {
@@ -99,7 +99,7 @@ PUBLIC int kernel_portal_unlink(int portalid)
 	if (portalid < 0)
 		return (-EINVAL);
 
-	return (do_portal_unlink(portalid));
+	return (do_vportal_unlink(portalid));
 }
 
 /*============================================================================*
@@ -107,7 +107,7 @@ PUBLIC int kernel_portal_unlink(int portalid)
  *============================================================================*/
 
 /**
- * @see do_portal_close().
+ * @see do_vportal_close().
  */
 PUBLIC int kernel_portal_close(int portalid)
 {
@@ -115,7 +115,7 @@ PUBLIC int kernel_portal_close(int portalid)
 	if (portalid < 0)
 		return (-EINVAL);
 
-	return (do_portal_close(portalid));
+	return (do_vportal_close(portalid));
 }
 
 /*============================================================================*
@@ -123,7 +123,7 @@ PUBLIC int kernel_portal_close(int portalid)
  *============================================================================*/
 
 /**
- * @see do_portal_awrite().
+ * @see do_vportal_awrite().
  */
 PUBLIC int kernel_portal_awrite(int portalid, const void * buffer, size_t size)
 {
@@ -143,7 +143,7 @@ PUBLIC int kernel_portal_awrite(int portalid, const void * buffer, size_t size)
 	if (!mm_check_area(VADDR(buffer), size, UMEM_AREA))
 		return (-EFAULT);
 
-	return (do_portal_awrite(portalid, buffer, size));
+	return (do_vportal_awrite(portalid, buffer, size));
 }
 
 /*============================================================================*
@@ -151,7 +151,7 @@ PUBLIC int kernel_portal_awrite(int portalid, const void * buffer, size_t size)
  *============================================================================*/
 
 /**
- * @see do_portal_aread().
+ * @see do_vportal_aread().
  */
 PUBLIC int kernel_portal_aread(int portalid, void * buffer, size_t size)
 {
@@ -171,7 +171,7 @@ PUBLIC int kernel_portal_aread(int portalid, void * buffer, size_t size)
 	if (!mm_check_area(VADDR(buffer), size, UMEM_AREA))
 		return (-EFAULT);
 
-	return (do_portal_aread(portalid, buffer, size));
+	return (do_vportal_aread(portalid, buffer, size));
 }
 
 /*============================================================================*
@@ -179,7 +179,7 @@ PUBLIC int kernel_portal_aread(int portalid, void * buffer, size_t size)
  *============================================================================*/
 
 /**
- * @see do_portal_wait().
+ * @see do_vportal_wait().
  */
 PUBLIC int kernel_portal_wait(int portalid)
 {
@@ -187,7 +187,7 @@ PUBLIC int kernel_portal_wait(int portalid)
 	if (portalid < 0)
 		return (-EINVAL);
 
-	return (do_portal_wait(portalid));
+	return (do_vportal_wait(portalid));
 }
 
 /*============================================================================*
@@ -195,7 +195,7 @@ PUBLIC int kernel_portal_wait(int portalid)
  *============================================================================*/
 
 /**
- * @see do_portal_ioctl().
+ * @see do_vportal_ioctl().
  */
 PUBLIC int kernel_portal_ioctl(int portalid, unsigned request, va_list *args)
 {
@@ -210,7 +210,7 @@ PUBLIC int kernel_portal_ioctl(int portalid, unsigned request, va_list *args)
 		return (-EINVAL);
 
 	dcache_invalidate();
-		ret = do_portal_ioctl(portalid, request, *args);
+		ret = do_vportal_ioctl(portalid, request, *args);
 	dcache_invalidate();
 
 	return (ret);


### PR DESCRIPTION
# Description
In this PR was added the support and multiplexing of virtual portals. Now, the user can call multiple open and create calls, limited only by KPORTAL_MAX constant, that limits the number of virtual portals that can be created.
In addition, was added the function `do_portal_search()` to simplify the logic when looking for already existing HW portals on `_do_portal_create()` and `_do_portal_open()`.

# Related Issues
[#198 - [ikc] Multiplex HW Portals](https://github.com/nanvix/microkernel/issues/198)
[#190 - [ikc] Portal Search](https://github.com/nanvix/microkernel/issues/190)