### PR TITLE
[ikc] Multiplex HW Syncs

### DIFF
--- a/include/nanvix/kernel/sync.h
+++ b/include/nanvix/kernel/sync.h
@@ -36,72 +36,79 @@
 	#include <nanvix/const.h>
 
 	/**
-	 * @brief Creates a synchronization point.
+	 * @brief Maximum number of virtual syncs.
 	 *
-	 * @param nodes  Logic IDs of Target Nodes.
-	 * @param nnodes Number of Target Nodes.
+	 * Maximum number of virtual syncs that may be created/opened.
+	 */
+	#define KSYNC_MAX 1024
+
+	/**
+	 * @brief Creates a virtual synchronization point.
+	 *
+	 * @param nodes  Logic IDs of target nodes.
+	 * @param nnodes Number of target nodes.
 	 * @param type   Type of synchronization point.
 	 *
 	 * @returns Upon successful completion, the ID of the newly created
-	 * synchronization point is returned. Upon failure, a negative error
-	 * code is returned instead.
+	 * virtual synchronization point is returned. Upon failure, a negative
+	 * error code is returned instead.
 	 */
-	EXTERN int do_sync_create(const int * nodes, int nnodes, int type);
+	EXTERN int do_vsync_create(const int *nodes, int nnodes, int type);
 
 	/**
-	 * @brief Opens a synchronization point.
+	 * @brief Opens a virtual synchronization point.
 	 *
-	 * @param nodes  Logic IDs of Target Nodes.
-	 * @param nnodes Number of Target Nodes.
+	 * @param nodes  Logic IDs of target nodes.
+	 * @param nnodes Number of target nodes.
 	 * @param type   Type of synchronization point.
 	 *
-	 * @returns Upon successful completion, the ID of the target
+	 * @returns Upon successful completion, the ID of the opened virtual
 	 * synchronization point is returned. Upon failure, a negative error
 	 * code is returned instead.
 	 *
 	 * @todo Check for Invalid Remote
 	 */
-	EXTERN int do_sync_open(const int *nodes, int nnodes, int type);
-
-		/**
-	 * @brief Destroys a synchronization point.
-	 *
-	 * @param syncid ID of the target synchronization point.
-	 *
-	 * @returns Upon successful completion, zero is returned. Upon
-	 * failure, a negative error code is returned instead.
-	 */
-	EXTERN int do_sync_unlink(int syncid);
+	EXTERN int do_vsync_open(const int *nodes, int nnodes, int type);
 
 	/**
-	 * @brief Closes a synchronization point.
+	 * @brief Destroys a virtual synchronization point.
 	 *
-	 * @param syncid ID of the target synchronization point.
+	 * @param syncid ID of the target virtual synchronization point.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN int do_sync_close(int syncid);
+	EXTERN int do_vsync_unlink(int syncid);
+
+	/**
+	 * @brief Closes a virtual synchronization point.
+	 *
+	 * @param syncid ID of the target virtual synchronization point.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
+	 */
+	EXTERN int do_vsync_close(int syncid);
 
 	/**
 	 * @brief Waits on a synchronization point.
 	 *
-	 * @param syncid ID of the target synchronization point.
+	 * @param syncid ID of the target virtual synchronization point.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN int do_sync_wait(int syncid);
+	EXTERN int do_vsync_wait(int syncid);
 
 	/**
-	 * @brief Signals Waits on a synchronization point.
+	 * @brief Signals nodes waiting on a synchronization point.
 	 *
-	 * @param syncid ID of the target synchronization point.
+	 * @param syncid ID of the target virtual synchronization point.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN int do_sync_signal(int syncid);
+	EXTERN int do_vsync_signal(int syncid);
 
 #endif /* NANVIX_SYNC_H_ */
 

--- a/src/kernel/noc/mailbox.c
+++ b/src/kernel/noc/mailbox.c
@@ -88,16 +88,15 @@ PRIVATE const struct resource_pool mbxpool = {
  *============================================================================*/
 
 /**
- * @brief Asserts whether or not a synchronization point is valid.
+ * @brief Asserts whether or not a virtual mailbox ID is valid.
  *
  * @param mbxid ID of the Target Mailbox.
  *
- * @returns One if the target synchronization point is valid, and false
- * otherwise.
+ * @returns One if the mailboxID is valid, and false otherwise.
  */
 PRIVATE int do_vmailbox_is_valid(int mbxid)
 {
-	return WITHIN(mbxid, 0, (KMAILBOX_MAX));
+	return WITHIN(mbxid, 0, KMAILBOX_MAX);
 }
 
 /*============================================================================*
@@ -245,9 +244,9 @@ PUBLIC int do_vmailbox_create(int local)
 		return (mbxid);
 
 	/* Initialize virtual mailbox. */
-	virtual_mailboxes[vmbxid].fd       = mbxid;
-	virtual_mailboxes[vmbxid].volume   = 0ULL;
-	virtual_mailboxes[vmbxid].latency  = 0ULL;
+	virtual_mailboxes[vmbxid].fd      = mbxid;
+	virtual_mailboxes[vmbxid].volume  = 0ULL;
+	virtual_mailboxes[vmbxid].latency = 0ULL;
 	active_mailboxes[mbxid].refcount++;
 
 	dcache_invalidate();
@@ -387,7 +386,7 @@ PUBLIC int do_vmailbox_unlink(int mbxid)
 	if (!resource_is_readable(&active_mailboxes[fd].resource))
 		return (-EBADF);
 
-	/* Unlink hardware mailbox. */
+	/* Unlink virtual mailbox. */
 	virtual_mailboxes[mbxid].fd = -1;
 	active_mailboxes[fd].refcount--;
 

--- a/src/kernel/noc/sync.c
+++ b/src/kernel/noc/sync.c
@@ -28,6 +28,14 @@
 
 #if __TARGET_HAS_SYNC
 
+/**
+ * @brief Search types for do_sync_search().
+ */
+enum sync_search_type {
+	SYNC_SEARCH_INPUT = 0,
+	SYNC_SEARCH_OUTPUT = 1
+} resource_type_enum_t;
+
 /*============================================================================*
  * Control Structures.                                                        *
  *============================================================================*/
@@ -42,7 +50,7 @@ PRIVATE struct sync
 	int fd;                   /**< Underlying file descriptor. */
 	int type;                 /**< Sync type.                  */
 	int masternum;            /**< Node number of the ONE.     */
-	uint64_t footprint;       /**< Node ID list.               */
+	uint64_t nodeslist;       /**< Node ID list.               */
 } ALIGN(sizeof(dword_t)) synctab[(SYNC_CREATE_MAX + SYNC_OPEN_MAX)];
 
 /**
@@ -74,22 +82,88 @@ PRIVATE int do_sync_is_valid(int syncid)
 }
 
 /*============================================================================*
+ * do_sync_search()                                                        *
+ *============================================================================*/
+
+/**
+ * @name Helper Macros for do_sync_search()
+ */
+/**@{*/
+
+/**
+ * @brief Asserts an input sync.
+ */
+#define SYNC_SEARCH_IS_INPUT(mbxid,type) \
+	((type == SYNC_SEARCH_INPUT) && !resource_is_readable(&synctab[mbxid].resource))
+
+/**
+ * @brief Asserts an output sync.
+ */
+#define SYNC_SEARCH_IS_OUTPUT(mbxid,type) \
+	 ((type == SYNC_SEARCH_OUTPUT) && !resource_is_writable(&synctab[mbxid].resource))
+/**@}*/
+
+/**
+ * @brief Searches for a sync.
+ *
+ * Searches for an already existing sync in synctab.
+ *
+ * @param masternum    Logic ID of the master node.
+ * @param nodeslist    Target nodes list.
+ * @param sync_type    Type of synchronization type.
+ * @param search_type  Type of the searched resource.
+ *
+ * @returns Upon successful completion, the ID of the sync found is
+ * returned. Upon failure, a negative error code is returned instead.
+ */
+PRIVATE int do_sync_search(int masternum, uint64_t nodeslist, int sync_type, enum sync_search_type search_type)
+{
+	for (int i = 0; i < (SYNC_CREATE_MAX + SYNC_OPEN_MAX); ++i)
+	{
+		if (!resource_is_used(&synctab[i].resource))
+			continue;
+
+		if (SYNC_SEARCH_IS_INPUT(i, search_type))
+			continue;
+
+		else if (SYNC_SEARCH_IS_OUTPUT(i, search_type))
+			continue;
+
+		/* Not the same master? */
+		if (synctab[i].masternum != masternum)
+			continue;
+
+		/* Not the same node list? */
+		if (synctab[i].nodeslist != nodeslist)
+			continue;
+
+		/* Not the same type operation? */
+		if (synctab[i].type != sync_type)
+			continue;
+
+		return (i);
+	}
+
+	return (-1);
+}
+
+/*============================================================================*
  * do_sync_create()                                                           *
  *============================================================================*/
 
 /**
  * @brief Creates a synchronization point.
  *
- * @param nodes     Logic IDs of Target Nodes.
- * @param nnodes    Number of Target Nodes.
- * @param type      Type of synchronization point.
- * @param footprint Target nodes footprint.
+ * @param nodes      Logic IDs of target nodes.
+ * @param nnodes     Number of target nodes.
+ * @param type       Type of synchronization point.
+ * @param nodeslist  Target nodes list.
  *
  * @returns Upon successful completion, the ID of the newly created
  * synchronization point is returned. Upon failure, a negative error
  * code is returned instead.
  */
-PRIVATE int _do_sync_create(const int *nodes, int nnodes, int type, uint64_t footprint)
+PRIVATE int _do_sync_create(const int *nodes, int nnodes, int type, uint64_t nodeslist)
 {
 	int fd;
 	int syncid;
@@ -107,9 +181,9 @@ PRIVATE int _do_sync_create(const int *nodes, int nnodes, int type, uint64_t foo
 	/* Initialize synchronization point. */
 	synctab[syncid].fd        = fd;
 	synctab[syncid].type      = type;
-	synctab[syncid].refcount  = 1;
+	synctab[syncid].refcount  = 0;
 	synctab[syncid].masternum = nodes[0];
-	synctab[syncid].footprint = footprint;
+	synctab[syncid].nodeslist = nodeslist;
 
 	resource_set_rdonly(&synctab[syncid].resource);
 	resource_set_notbusy(&synctab[syncid].resource);
@@ -123,45 +197,22 @@ PRIVATE int _do_sync_create(const int *nodes, int nnodes, int type, uint64_t foo
 PUBLIC int do_sync_create(const int *nodes, int nnodes, int type)
 {
 	int syncid;         /* Synchronization point.  */
-	uint64_t footprint; /* Target nodes footprint. */
+	uint64_t nodeslist; /* Target nodes list. */
 
-	footprint = 0ULL;
+	nodeslist = 0ULL;
 	for (int j = 0; j < nnodes; j++)
-		footprint |= (1ULL << nodes[j]);
+		nodeslist |= (1ULL << nodes[j]);
 
 	/* Searchs for existing syncs. */
-	for (int i = 0; i < (SYNC_CREATE_MAX + SYNC_OPEN_MAX); ++i)
+	if ((syncid = do_sync_search(nodes[0], nodeslist, type, SYNC_SEARCH_INPUT)) < 0)
 	{
-		if (!resource_is_used(&synctab[i].resource))
-			continue;
-
-		if (!resource_is_readable(&synctab[i].resource))
-			continue;
-
-		/* Not the same master? */
-		if (synctab[i].masternum != nodes[0])
-			continue;
-
-		/* Not the same node list? */
-		if (synctab[i].footprint != footprint)
-			continue;
-
-		/* Not the same type operation? */
-		if (synctab[i].type != type)
-			continue;
-
-		syncid = i;
-		synctab[i].refcount++;
-
-		goto found;
+		/* Alloc a new synchronization point. */
+		syncid = _do_sync_create(nodes, nnodes, type, nodeslist);
 	}
 
-	/* Alloc a new synchronization point. */
-	syncid = _do_sync_create(nodes, nnodes, type, footprint);
+	synctab[syncid].refcount++;
 
-found:
 	dcache_invalidate();
-
 	return (syncid);
 }
 
@@ -172,10 +223,10 @@ found:
 /**
  * @brief Opens a synchronization point.
  *
- * @param nodes  Logic IDs of Target Nodes.
- * @param nnodes Number of Target Nodes.
- * @param type   Type of synchronization point.
- * @param footprint Target nodes footprint.
+ * @param nodes      Logic IDs of target nodes.
+ * @param nnodes     Number of target nodes.
+ * @param type       Type of synchronization point.
+ * @param nodeslist  Target nodes list.
  *
  * @returns Upon successful completion, the ID of the target
  * synchronization point is returned. Upon failure, a negative error
@@ -183,7 +234,7 @@ found:
  *
  * @todo Check for Invalid Remote
  */
-PRIVATE int _do_sync_open(const int *nodes, int nnodes, int type, uint64_t footprint)
+PRIVATE int _do_sync_open(const int *nodes, int nnodes, int type, uint64_t nodeslist)
 {
 	int fd;		/* File descriptor.       */
 	int syncid; /* Synchronization point. */
@@ -202,9 +253,9 @@ PRIVATE int _do_sync_open(const int *nodes, int nnodes, int type, uint64_t footp
 	/* Initialize synchronization point. */
 	synctab[syncid].fd        = fd;
 	synctab[syncid].type      = type;
-	synctab[syncid].refcount  = 1;
+	synctab[syncid].refcount  = 0;
 	synctab[syncid].masternum = nodes[0];
-	synctab[syncid].footprint = footprint;
+	synctab[syncid].nodeslist = nodeslist;
 
 	resource_set_wronly(&synctab[syncid].resource);
 	resource_set_notbusy(&synctab[syncid].resource);
@@ -218,45 +269,22 @@ PRIVATE int _do_sync_open(const int *nodes, int nnodes, int type, uint64_t footp
 PUBLIC int do_sync_open(const int *nodes, int nnodes, int type)
 {
 	int syncid;         /* Synchronization point.  */
-	uint64_t footprint; /* Target nodes footprint. */
+	uint64_t nodeslist; /* Target nodes list.      */
 
-	footprint = 0ULL;
+	nodeslist = 0ULL;
 	for (int j = 0; j < nnodes; j++)
-		footprint |= (1ULL << nodes[j]);
+		nodeslist |= (1ULL << nodes[j]);
 
 	/* Searchs for existing syncs. */
-	for (int i = 0; i < (SYNC_CREATE_MAX + SYNC_OPEN_MAX); ++i)
+	if ((syncid = do_sync_search(nodes[0], nodeslist, type, SYNC_SEARCH_OUTPUT)) < 0)
 	{
-		if (!resource_is_used(&synctab[i].resource))
-			continue;
-
-		if (!resource_is_writable(&synctab[i].resource))
-			continue;
-
-		/* Not the same master? */
-		if (synctab[i].masternum != nodes[0])
-			continue;
-
-		/* Not the same node list? */
-		if (synctab[i].footprint != footprint)
-			continue;
-
-		/* Not the same type operation? */
-		if (synctab[i].type != type)
-			continue;
-
-		syncid = i;
-		synctab[i].refcount++;
-
-		goto found;
+		/* Alloc a new synchronization point. */
+		syncid = _do_sync_open(nodes, nnodes, type, nodeslist);
 	}
 
-	/* Alloc a new synchronization point. */
-	syncid = _do_sync_open(nodes, nnodes, type, footprint);
+	synctab[syncid].refcount++;
 
-found:
 	dcache_invalidate();
-
 	return (syncid);
 }
 
@@ -286,7 +314,7 @@ PRIVATE int _do_sync_release(int syncid, int (*release_fn)(int))
 
 		synctab[syncid].fd        = -1;
 		synctab[syncid].masternum = -1;
-		synctab[syncid].footprint = 0ULL;
+		synctab[syncid].nodeslist = 0ULL;
 
 		resource_free(&syncpool, syncid);
 

--- a/src/kernel/noc/sync.c
+++ b/src/kernel/noc/sync.c
@@ -377,7 +377,7 @@ PRIVATE int _do_sync_release(int syncid, int (*release_fn)(int))
 	if ((ret = release_fn(active_syncs[syncid].hwfd)) < 0)
 		return (ret);
 
-	active_syncs[syncid].hwfd        = -1;
+	active_syncs[syncid].hwfd      = -1;
 	active_syncs[syncid].masternum = -1;
 	active_syncs[syncid].nodeslist = 0ULL;
 

--- a/src/kernel/noc/sync.c
+++ b/src/kernel/noc/sync.c
@@ -23,6 +23,7 @@
  */
 
 #include <nanvix/hal/hal.h>
+#include <nanvix/kernel/sync.h>
 #include <nanvix/hlib.h>
 #include <posix/errno.h>
 
@@ -41,44 +42,54 @@ enum sync_search_type {
  *============================================================================*/
 
 /**
- * @brief Table of synchronization points.
+ * @brief Table of virtual synchronization points.
+ */
+PRIVATE struct
+{
+	int fd; /**< Index to table of active syncs. */
+} ALIGN(sizeof(dword_t)) virtual_syncs[KSYNC_MAX] = {
+	[0 ... (KSYNC_MAX - 1)] = { .fd = -1 },
+};
+
+/**
+ * @brief Table of active synchronization points.
  */
 PRIVATE struct sync
 {
 	struct resource resource; /**< Underlying resource.        */
 	int refcount;             /**< References count.           */
-	int fd;                   /**< Underlying file descriptor. */
-	int type;                 /**< Sync type.                  */
+	int hwfd;                 /**< Underlying file descriptor. */
 	int masternum;            /**< Node number of the ONE.     */
+	int type;                 /**< Sync type.                  */
 	uint64_t nodeslist;       /**< Node ID list.               */
-} ALIGN(sizeof(dword_t)) synctab[(SYNC_CREATE_MAX + SYNC_OPEN_MAX)];
+} active_syncs[(SYNC_CREATE_MAX + SYNC_OPEN_MAX)];
 
 /**
  * @brief Resource pool.
  */
 PRIVATE const struct resource_pool syncpool = {
-	synctab, (SYNC_CREATE_MAX + SYNC_OPEN_MAX), sizeof(struct sync)
+	active_syncs, (SYNC_CREATE_MAX + SYNC_OPEN_MAX), sizeof(struct sync)
 };
 
 /*============================================================================*
- * do_sync_is_valid()                                                         *
+ * do_vsync_is_valid()                                                         *
  *============================================================================*/
 
 /**
- * @brief Asserts whether or not a synchronization point is valid.
+ * @brief Asserts whether or not a virtual synchronization point is valid.
  *
- * @param syncid ID of the target synchronization point.
+ * @param syncid ID of the target virtual synchronization point.
  *
- * @returns One if the target synchronization point is valid, and false
+ * @returns One if the virtual synchronization point is valid, and false
  * otherwise.
  *
  * @note This function is non-blocking.
  * @note This function is thread-safe.
  * @note This function is reentrant.
  */
-PRIVATE int do_sync_is_valid(int syncid)
+PRIVATE int do_vsync_is_valid(int syncid)
 {
-	return WITHIN(syncid, 0, (SYNC_CREATE_MAX + SYNC_OPEN_MAX));
+	return WITHIN(syncid, 0, KSYNC_MAX);
 }
 
 /*============================================================================*
@@ -93,20 +104,20 @@ PRIVATE int do_sync_is_valid(int syncid)
 /**
  * @brief Asserts an input sync.
  */
-#define SYNC_SEARCH_IS_INPUT(mbxid,type) \
-	((type == SYNC_SEARCH_INPUT) && !resource_is_readable(&synctab[mbxid].resource))
+#define SYNC_SEARCH_IS_INPUT(syncid,type) \
+	((type == SYNC_SEARCH_INPUT) && !resource_is_readable(&active_syncs[syncid].resource))
 
 /**
  * @brief Asserts an output sync.
  */
-#define SYNC_SEARCH_IS_OUTPUT(mbxid,type) \
-	 ((type == SYNC_SEARCH_OUTPUT) && !resource_is_writable(&synctab[mbxid].resource))
+#define SYNC_SEARCH_IS_OUTPUT(syncid,type) \
+	 ((type == SYNC_SEARCH_OUTPUT) && !resource_is_writable(&active_syncs[syncid].resource))
 /**@}*/
 
 /**
  * @brief Searches for a sync.
  *
- * Searches for an already existing sync in synctab.
+ * Searches for an already existing sync in active_syncs.
  *
  * @param masternum    Logic ID of the master node.
  * @param nodeslist    Target nodes list.
@@ -120,7 +131,7 @@ PRIVATE int do_sync_search(int masternum, uint64_t nodeslist, int sync_type, enu
 {
 	for (int i = 0; i < (SYNC_CREATE_MAX + SYNC_OPEN_MAX); ++i)
 	{
-		if (!resource_is_used(&synctab[i].resource))
+		if (!resource_is_used(&active_syncs[i].resource))
 			continue;
 
 		if (SYNC_SEARCH_IS_INPUT(i, search_type))
@@ -130,15 +141,15 @@ PRIVATE int do_sync_search(int masternum, uint64_t nodeslist, int sync_type, enu
 			continue;
 
 		/* Not the same master? */
-		if (synctab[i].masternum != masternum)
+		if (active_syncs[i].masternum != masternum)
 			continue;
 
 		/* Not the same node list? */
-		if (synctab[i].nodeslist != nodeslist)
+		if (active_syncs[i].nodeslist != nodeslist)
 			continue;
 
 		/* Not the same type operation? */
-		if (synctab[i].type != sync_type)
+		if (active_syncs[i].type != sync_type)
 			continue;
 
 		return (i);
@@ -148,16 +159,38 @@ PRIVATE int do_sync_search(int masternum, uint64_t nodeslist, int sync_type, enu
 }
 
 /*============================================================================*
- * do_sync_create()                                                           *
+ * do_vsync_alloc()                                                        *
  *============================================================================*/
 
 /**
- * @brief Creates a synchronization point.
+ * @brief Searches for a free virtual synchronization point.
  *
- * @param nodes      Logic IDs of target nodes.
- * @param nnodes     Number of target nodes.
- * @param type       Type of synchronization point.
- * @param nodeslist  Target nodes list.
+ * @returns Upon successful completion, the index of the virtual sync found
+ * is returned. Upon failure, a negative number is returned instead.
+ */
+PRIVATE int do_vsync_alloc(void)
+{
+	for (int i = 0; i < KSYNC_MAX; ++i)
+	{
+		/* Found. */
+		if (virtual_syncs[i].fd < 0)
+			return (i);
+	}
+
+	return (-1);
+}
+
+/*============================================================================*
+ * do_vsync_create()                                                           *
+ *============================================================================*/
+
+/**
+ * @brief Creates a hardware synchronization point.
+ *
+ * @param nodes     Logic IDs of target nodes.
+ * @param nnodes    Number of target nodes.
+ * @param type      Type of synchronization point.
+ * @param nodeslist Target nodes footprint.
  *
  * @returns Upon successful completion, the ID of the newly created
  * synchronization point is returned. Upon failure, a negative error
@@ -165,70 +198,87 @@ PRIVATE int do_sync_search(int masternum, uint64_t nodeslist, int sync_type, enu
  */
 PRIVATE int _do_sync_create(const int *nodes, int nnodes, int type, uint64_t nodeslist)
 {
-	int fd;
-	int syncid;
+	int hwfd;   /* File descriptor.       */
+	int syncid; /* Synchronization point. */
+
+	/* Search target hardware synchronization point. */
+	if ((syncid = do_sync_search(nodes[0], nodeslist, type, SYNC_SEARCH_INPUT)) >= 0)
+		return (syncid);
 
 	/* Allocate a synchronization point. */
 	if ((syncid = resource_alloc(&syncpool)) < 0)
 		return (-EAGAIN);
 
-	if ((fd = sync_create(nodes, nnodes, type)) < 0)
+	if ((hwfd = sync_create(nodes, nnodes, type)) < 0)
 	{
 		resource_free(&syncpool, syncid);
-		return (fd);
+		return (hwfd);
 	}
 
 	/* Initialize synchronization point. */
-	synctab[syncid].fd        = fd;
-	synctab[syncid].type      = type;
-	synctab[syncid].refcount  = 0;
-	synctab[syncid].masternum = nodes[0];
-	synctab[syncid].nodeslist = nodeslist;
+	active_syncs[syncid].hwfd      = hwfd;
+	active_syncs[syncid].type      = type;
+	active_syncs[syncid].refcount  = 0;
+	active_syncs[syncid].masternum = nodes[0];
+	active_syncs[syncid].nodeslist = nodeslist;
 
-	resource_set_rdonly(&synctab[syncid].resource);
-	resource_set_notbusy(&synctab[syncid].resource);
+	resource_set_rdonly(&active_syncs[syncid].resource);
+	resource_set_notbusy(&active_syncs[syncid].resource);
 
 	return (syncid);
 }
 
 /**
- * @see _do_sync_create().
+ * @brief Creates a virtual synchronization point.
+ *
+ * @param nodes     Logic IDs of target nodes.
+ * @param nnodes    Number of target nodes.
+ * @param type      Type of synchronization point.
+ * @param nodeslist Target nodes list.
+ *
+ * @returns Upon successful completion, the ID of the newly created
+ * virtual synchronization point is returned. Upon failure, a negative
+ * error code is returned instead.
  */
-PUBLIC int do_sync_create(const int *nodes, int nnodes, int type)
+PUBLIC int do_vsync_create(const int *nodes, int nnodes, int type)
 {
-	int syncid;         /* Synchronization point.  */
-	uint64_t nodeslist; /* Target nodes list. */
+	int syncid;         /* HW sync point ID.      */
+	int vsyncid;        /* Virtual sync point ID. */
+	uint64_t nodeslist; /* Target nodes list.     */
+
+	/* Allocate a virtual synchronization point. */
+	if ((vsyncid = do_vsync_alloc()) < 0)
+		return (-EAGAIN);
 
 	nodeslist = 0ULL;
 	for (int j = 0; j < nnodes; j++)
 		nodeslist |= (1ULL << nodes[j]);
 
-	/* Searchs for existing syncs. */
-	if ((syncid = do_sync_search(nodes[0], nodeslist, type, SYNC_SEARCH_INPUT)) < 0)
-	{
-		/* Alloc a new synchronization point. */
-		syncid = _do_sync_create(nodes, nnodes, type, nodeslist);
-	}
+	/* Create a synchronization point. */
+	if ((syncid = _do_sync_create(nodes, nnodes, type, nodeslist)) < 0)
+		return (syncid);
 
-	synctab[syncid].refcount++;
+	/* Initialize virtual synchronization point. */
+	virtual_syncs[vsyncid].fd = syncid;
+	active_syncs[syncid].refcount++;
 
 	dcache_invalidate();
-	return (syncid);
+	return (vsyncid);
 }
 
 /*============================================================================*
- * do_sync_open()                                                             *
+ * do_vsync_open()                                                             *
  *============================================================================*/
 
 /**
- * @brief Opens a synchronization point.
+ * @brief Opens a hardware synchronization point.
  *
- * @param nodes      Logic IDs of target nodes.
- * @param nnodes     Number of target nodes.
- * @param type       Type of synchronization point.
- * @param nodeslist  Target nodes list.
+ * @param nodes     Logic IDs of target nodes.
+ * @param nnodes    Number of target nodes.
+ * @param type      Type of synchronization point.
+ * @param nodeslist Target nodes list.
  *
- * @returns Upon successful completion, the ID of the target
+ * @returns Upon successful completion, the ID of the opened
  * synchronization point is returned. Upon failure, a negative error
  * code is returned instead.
  *
@@ -236,56 +286,75 @@ PUBLIC int do_sync_create(const int *nodes, int nnodes, int type)
  */
 PRIVATE int _do_sync_open(const int *nodes, int nnodes, int type, uint64_t nodeslist)
 {
-	int fd;		/* File descriptor.       */
+	int hwfd;   /* File descriptor.       */
 	int syncid; /* Synchronization point. */
+
+	/* Search target hardware synchronization point. */
+	if ((syncid = do_sync_search(nodes[0], nodeslist, type, SYNC_SEARCH_OUTPUT)) >= 0)
+		return (syncid);
 
 	/* Allocate a synchronization point. */
 	if ((syncid = resource_alloc(&syncpool)) < 0)
 		return (-EAGAIN);
 
 	/* Open connector. */
-	if ((fd = sync_open(nodes, nnodes, type)) < 0)
+	if ((hwfd = sync_open(nodes, nnodes, type)) < 0)
 	{
 		resource_free(&syncpool, syncid);
-		return (fd);
+		return (hwfd);
 	}
 
 	/* Initialize synchronization point. */
-	synctab[syncid].fd        = fd;
-	synctab[syncid].type      = type;
-	synctab[syncid].refcount  = 0;
-	synctab[syncid].masternum = nodes[0];
-	synctab[syncid].nodeslist = nodeslist;
+	active_syncs[syncid].hwfd      = hwfd;
+	active_syncs[syncid].type      = type;
+	active_syncs[syncid].refcount  = 0;
+	active_syncs[syncid].masternum = nodes[0];
+	active_syncs[syncid].nodeslist = nodeslist;
 
-	resource_set_wronly(&synctab[syncid].resource);
-	resource_set_notbusy(&synctab[syncid].resource);
+	resource_set_wronly(&active_syncs[syncid].resource);
+	resource_set_notbusy(&active_syncs[syncid].resource);
 
 	return (syncid);
 }
 
 /**
- * @see _do_sync_open().
+ * @brief Opens a virtual synchronization point.
+ *
+ * @param nodes     Logic IDs of target nodes.
+ * @param nnodes    Number of target nodes.
+ * @param type      Type of synchronization point.
+ * @param nodeslist Target nodes list.
+ *
+ * @returns Upon successful completion, the ID of the opened virtual
+ * synchronization point is returned. Upon failure, a negative error
+ * code is returned instead.
+ *
+ * @todo Check for Invalid Remote
  */
-PUBLIC int do_sync_open(const int *nodes, int nnodes, int type)
+PUBLIC int do_vsync_open(const int *nodes, int nnodes, int type)
 {
-	int syncid;         /* Synchronization point.  */
+	int syncid;         /* HW sync point ID.      */
+	int vsyncid;        /* Virtual sync point ID. */
 	uint64_t nodeslist; /* Target nodes list.      */
+
+	/* Allocate a virtual synchronization point. */
+	if ((vsyncid = do_vsync_alloc()) < 0)
+		return (-EAGAIN);
 
 	nodeslist = 0ULL;
 	for (int j = 0; j < nnodes; j++)
 		nodeslist |= (1ULL << nodes[j]);
 
-	/* Searchs for existing syncs. */
-	if ((syncid = do_sync_search(nodes[0], nodeslist, type, SYNC_SEARCH_OUTPUT)) < 0)
-	{
-		/* Alloc a new synchronization point. */
-		syncid = _do_sync_open(nodes, nnodes, type, nodeslist);
-	}
+	/* Create a synchronization point. */
+	if ((syncid = _do_sync_open(nodes, nnodes, type, nodeslist)) < 0)
+		return (syncid);
 
-	synctab[syncid].refcount++;
+	/* Initialize virtual synchronization point. */
+	virtual_syncs[vsyncid].fd = syncid;
+	active_syncs[syncid].refcount++;
 
 	dcache_invalidate();
-	return (syncid);
+	return (vsyncid);
 }
 
 /*============================================================================*
@@ -293,7 +362,7 @@ PUBLIC int do_sync_open(const int *nodes, int nnodes, int type)
  *============================================================================*/
 
 /**
- * @brief Relase a synchronization resource.
+ * @brief Release a synchronization resource.
  *
  * @param syncid     ID of the target synchronization point.
  * @param release_fn Underlying release function.
@@ -305,127 +374,161 @@ PRIVATE int _do_sync_release(int syncid, int (*release_fn)(int))
 {
 	int ret; /* HAL function return. */
 
-	synctab[syncid].refcount--;
+	if ((ret = release_fn(active_syncs[syncid].hwfd)) < 0)
+		return (ret);
 
-	if (synctab[syncid].refcount == 0)
-	{
-		if ((ret = release_fn(synctab[syncid].fd)) < 0)
-			return (ret);
+	active_syncs[syncid].hwfd        = -1;
+	active_syncs[syncid].masternum = -1;
+	active_syncs[syncid].nodeslist = 0ULL;
 
-		synctab[syncid].fd        = -1;
-		synctab[syncid].masternum = -1;
-		synctab[syncid].nodeslist = 0ULL;
+	resource_free(&syncpool, syncid);
 
-		resource_free(&syncpool, syncid);
+	dcache_invalidate();
+	return (0);
+}
 
-		dcache_invalidate();
-	}
+/*============================================================================*
+ * do_vsync_unlink()                                                           *
+ *============================================================================*/
+
+/**
+ * @brief Unlinks a created virtual synchronization point.
+ *
+ * @param syncid Logic ID of the target virtual synchronization point.
+ *
+ * @returns Upon successful completion, zero is returned. Upon
+ * failure, a negative error code is returned instead.
+ */
+PUBLIC int do_vsync_unlink(int syncid)
+{
+	int fd; /* Active_syncs table index. */
+
+	/* Invalid sync. */
+	if (!do_vsync_is_valid(syncid))
+		return (-EINVAL);
+
+	fd = virtual_syncs[syncid].fd;
+
+	/* Bad sync. */
+	if (!resource_is_used(&active_syncs[fd].resource))
+		return (-EBADF);
+
+	/* Bad sync. */
+	if (!resource_is_readable(&active_syncs[fd].resource))
+		return (-EBADF);
+
+	/* Unlink virtual synchronization point. */
+	virtual_syncs[syncid].fd = -1;
+	active_syncs[fd].refcount--;
+
+	/* Release underlying resource. */
+	if (active_syncs[fd].refcount == 0)
+		return (_do_sync_release(fd, sync_unlink));
 
 	return (0);
 }
 
 /*============================================================================*
- * do_sync_unlink()                                                           *
+ * do_vsync_close()                                                            *
  *============================================================================*/
 
 /**
- * @todo TODO: Provide a detailed description for this function.
+ * @brief Closes an opened virtual synchronization point.
+ *
+ * @param syncid Logic ID of the target virtual synchronization point.
+ *
+ * @returns Upon successful completion, zero is returned. Upon
+ * failure, a negative error code is returned instead.
  */
-PUBLIC int do_sync_unlink(int syncid)
+PUBLIC int do_vsync_close(int syncid)
 {
+	int fd; /* Active_syncs table index. */
+
 	/* Invalid sync. */
-	if (!do_sync_is_valid(syncid))
+	if (!do_vsync_is_valid(syncid))
 		return (-EINVAL);
 
+	fd = virtual_syncs[syncid].fd;
+
 	/* Bad sync. */
-	if (!resource_is_used(&synctab[syncid].resource))
+	if (!resource_is_used(&active_syncs[fd].resource))
 		return (-EBADF);
 
 	/* Bad sync. */
-	if (!resource_is_readable(&synctab[syncid].resource))
+	if (!resource_is_writable(&active_syncs[fd].resource))
 		return (-EBADF);
 
-	/* Release resource. */
-	return (_do_sync_release(syncid, sync_unlink));
+	/* Close virtual synchronization point. */
+	virtual_syncs[syncid].fd = -1;
+	active_syncs[fd].refcount--;
+
+	/* Release underlying resource. */
+	if (active_syncs[fd].refcount == 0)
+		return (_do_sync_release(fd, sync_close));
+
+	return (0);
 }
 
 /*============================================================================*
- * do_sync_close()                                                            *
+ * do_vsync_wait()                                                             *
  *============================================================================*/
 
 /**
  * @todo TODO: Provide a detailed description for this function.
  */
-PUBLIC int do_sync_close(int syncid)
+PUBLIC int do_vsync_wait(int syncid)
 {
+	int fd; /* Active_syncs table index. */
+
 	/* Invalid sync. */
-	if (!do_sync_is_valid(syncid))
+	if (!do_vsync_is_valid(syncid))
 		return (-EINVAL);
 
-	/* Bad sync. */
-	if (!resource_is_used(&synctab[syncid].resource))
-		return (-EBADF);
-
-	/* Bad sync. */
-	if (!resource_is_writable(&synctab[syncid].resource))
-		return (-EBADF);
-
-	/* Release resource. */
-	return (_do_sync_release(syncid, sync_close));
-}
-
-/*============================================================================*
- * do_sync_wait()                                                             *
- *============================================================================*/
-
-/**
- * @todo TODO: Provide a detailed description for this function.
- */
-PUBLIC int do_sync_wait(int syncid)
-{
-	/* Invalid sync. */
-	if (!do_sync_is_valid(syncid))
-		return (-EINVAL);
+	fd = virtual_syncs[syncid].fd;
 
 	dcache_invalidate();
 
 	/* Bad sync. */
-	if (!resource_is_used(&synctab[syncid].resource))
+	if (!resource_is_used(&active_syncs[fd].resource))
 		return (-EBADF);
 
 	/* Bad sync. */
-	if (!resource_is_readable(&synctab[syncid].resource))
+	if (!resource_is_readable(&active_syncs[fd].resource))
 		return (-EBADF);
 
 	/* Waits. */
-	return (sync_wait(synctab[syncid].fd));
+	return (sync_wait(active_syncs[fd].hwfd));
 }
 
 /*============================================================================*
- * do_sync_signal()                                                           *
+ * do_vsync_signal()                                                           *
  *============================================================================*/
 
 /**
  * @todo TODO: Provide a detailed description for this function.
  */
-PUBLIC int do_sync_signal(int syncid)
+PUBLIC int do_vsync_signal(int syncid)
 {
+	int fd; /* Active_syncs table index. */
+
 	/* Invalid sync. */
-	if (!do_sync_is_valid(syncid))
+	if (!do_vsync_is_valid(syncid))
 		return (-EINVAL);
+
+	fd = virtual_syncs[syncid].fd;
 
 	dcache_invalidate();
 
 	/* Bad sync. */
-	if (!resource_is_used(&synctab[syncid].resource))
+	if (!resource_is_used(&active_syncs[fd].resource))
 		return (-EBADF);
 
 	/* Bad sync. */
-	if (!resource_is_writable(&synctab[syncid].resource))
+	if (!resource_is_writable(&active_syncs[fd].resource))
 		return (-EBADF);
 
 	/* Sends signal. */
-	return (sync_signal(synctab[syncid].fd));
+	return (sync_signal(active_syncs[fd].hwfd));
 }
 
 #endif /* __TARGET_SYNC */

--- a/src/kernel/sys/sync.c
+++ b/src/kernel/sys/sync.c
@@ -34,7 +34,7 @@
  *============================================================================*/
 
 /**
- * @see sync_create().
+ * @see vsync_create().
  *
  * @retval -EINVAL IDs of nodes need to exist.
  * @retval -EINVAL At least 2 nodes and at most PROCESSOR_NOC_NODES_NUM must be involved.
@@ -65,7 +65,7 @@ PUBLIC int kernel_sync_create(const int *nodes, int nnodes, int type)
 	if ((type != SYNC_ONE_TO_ALL) && (type != SYNC_ALL_TO_ONE))
 		return (-EINVAL);
 
-	return (do_sync_create(nodes, nnodes, type));
+	return (do_vsync_create(nodes, nnodes, type));
 }
 
 /*============================================================================*
@@ -73,7 +73,7 @@ PUBLIC int kernel_sync_create(const int *nodes, int nnodes, int type)
  *============================================================================*/
 
 /**
- * @see sync_open().
+ * @see vsync_open().
  *
  * @retval -EINVAL IDs of nodes need to exist.
  * @retval -EINVAL At least 2 nodes and at most PROCESSOR_NOC_NODES_NUM must be involved.
@@ -104,7 +104,7 @@ PUBLIC int kernel_sync_open(const int *nodes, int nnodes, int type)
 	if ((type != SYNC_ONE_TO_ALL) && (type != SYNC_ALL_TO_ONE))
 		return (-EINVAL);
 
-	return (do_sync_open(nodes, nnodes, type));
+	return (do_vsync_open(nodes, nnodes, type));
 }
 
 /*============================================================================*
@@ -112,7 +112,7 @@ PUBLIC int kernel_sync_open(const int *nodes, int nnodes, int type)
  *============================================================================*/
 
 /**
- * @see sync_wait().
+ * @see vsync_wait().
  */
 PUBLIC int kernel_sync_wait(int syncid)
 {
@@ -120,7 +120,7 @@ PUBLIC int kernel_sync_wait(int syncid)
 	if (syncid < 0)
 		return (-EINVAL);
 
-	return (do_sync_wait(syncid));
+	return (do_vsync_wait(syncid));
 }
 
 /*============================================================================*
@@ -128,7 +128,7 @@ PUBLIC int kernel_sync_wait(int syncid)
  *============================================================================*/
 
 /**
- * @see sync_signal().
+ * @see vsync_signal().
  */
 PUBLIC int kernel_sync_signal(int syncid)
 {
@@ -136,7 +136,7 @@ PUBLIC int kernel_sync_signal(int syncid)
 	if (syncid < 0)
 		return (-EINVAL);
 
-	return (do_sync_signal(syncid));
+	return (do_vsync_signal(syncid));
 }
 
 /*============================================================================*
@@ -144,7 +144,7 @@ PUBLIC int kernel_sync_signal(int syncid)
  *============================================================================*/
 
 /**
- * @see sync_close().
+ * @see vsync_close().
  */
 PUBLIC int kernel_sync_close(int syncid)
 {
@@ -152,7 +152,7 @@ PUBLIC int kernel_sync_close(int syncid)
 	if (syncid < 0)
 		return (-EINVAL);
 
-	return (do_sync_close(syncid));
+	return (do_vsync_close(syncid));
 }
 
 /*============================================================================*
@@ -160,7 +160,7 @@ PUBLIC int kernel_sync_close(int syncid)
  *============================================================================*/
 
 /**
- * @see sync_unlink().
+ * @see vsync_unlink().
  */
 PUBLIC int kernel_sync_unlink(int syncid)
 {
@@ -168,7 +168,7 @@ PUBLIC int kernel_sync_unlink(int syncid)
 	if (syncid < 0)
 		return (-EINVAL);
 
-	return (do_sync_unlink(syncid));
+	return (do_vsync_unlink(syncid));
 }
 
 #endif /* __TARGET_SYNC */


### PR DESCRIPTION
# Description
In this PR was added the support and multiplexing of virtual synchronization points. Now, the user can call multiple open and create calls, limited only by KSYNC_MAX constant, that limits the number of virtual syncs that can be created.
In addition, was added the function `do_sync_search()` to simplify the logic when looking for already existing HW synchronization points on `_do_sync_create()` and `_do_sync_open()`.

# Related Issues
[#199 - [ikc] Multiplex HW Syncs](https://github.com/nanvix/microkernel/issues/199)
[#211 - [ikc] Sync Search](https://github.com/nanvix/microkernel/issues/211)