### PR TITLE
[ikc] Mailbox Messages Multiplex Bugfix

### DIFF
--- a/include/nanvix/kernel/mailbox.h
+++ b/include/nanvix/kernel/mailbox.h
@@ -45,33 +45,63 @@
 	/**@}*/
 
 	/**
+	 * @brief Number of ports per HW mailbox.
+	 *
+	 * Maximum number of virtual mailboxes that can be vinculated to each HW mailbox.
+	 */
+	#define MAILBOX_PORT_NR 16
+
+	/**
 	 * @brief Maximum number of virtual mailboxes.
 	 *
 	 * Maximum number of virtual mailboxes that may be created/opened.
 	 */
-	#define KMAILBOX_MAX 1024
+	#define KMAILBOX_MAX (MAILBOX_CREATE_MAX + MAILBOX_OPEN_MAX) * MAILBOX_PORT_NR
+
+	/**
+	 * @brief Mailbox message header size.
+	 *
+	 * Size of mailbox message header.
+	 */
+	#define KMAILBOX_MESSAGE_HEADER_SIZE (1 * sizeof(int))
+
+	/**
+	 * @brief Maximum number of message buffer resources.
+	 *
+	 * Maximum number of message buffers used to hold temporary data on kernel space.
+	 */
+	#define KMAILBOX_MESSAGE_BUFFERS_MAX 64
+
+	/**
+	 * @brief Mailbox message buffer max size.
+	 *
+	 * Maximum size of mailbox message data buffer.
+	 */
+	#define KMAILBOX_MESSAGE_SIZE (MAILBOX_MSG_SIZE - KMAILBOX_MESSAGE_HEADER_SIZE)
 
 	/**
 	 * @brief Creates a virtual mailbox.
 	 *
-	 * @param local Logic ID of the Local Node.
+	 * @param local Logic ID of the local node.
+	 * @param port  Target port in @p local node.
 	 *
 	 * @returns Upon successful completion, the ID of the newly created
 	 * mailbox is returned. Upon failure, a negative error code is
 	 * returned instead.
 	 */
-	EXTERN int do_vmailbox_create(int local);
+	EXTERN int do_vmailbox_create(int local, int port);
 
 	/**
 	 * @brief Opens a virtual mailbox.
 	 *
-	 * @param remote Logic ID of the Target Node.
+	 * @param remote      Logic ID of the target node.
+	 * @param remote_port Target port in @p remote node.
 	 *
 	 * @returns Upon successful completion, the ID of the target mailbox
 	 * is returned. Upon failure, a negative error code is returned
 	 * instead.
 	 */
-	EXTERN int do_vmailbox_open(int remote);
+	EXTERN int do_vmailbox_open(int remote, int remote_port);
 
 	/**
 	 * @brief Destroys a virtual mailbox.

--- a/include/nanvix/kernel/syscall.h
+++ b/include/nanvix/kernel/syscall.h
@@ -294,8 +294,8 @@
 
 #ifdef __NANVIX_MICROKERNEL
 
-	EXTERN int kernel_mailbox_create(int);
-	EXTERN int kernel_mailbox_open(int);
+	EXTERN int kernel_mailbox_create(int, int);
+	EXTERN int kernel_mailbox_open(int, int);
 	EXTERN int kernel_mailbox_unlink(int);
 	EXTERN int kernel_mailbox_close(int);
 	EXTERN int kernel_mailbox_aread(int, void *, size_t);

--- a/src/kernel/noc/mailbox.c
+++ b/src/kernel/noc/mailbox.c
@@ -38,9 +38,145 @@ enum mailbox_search_type {
 	MAILBOX_SEARCH_OUTPUT = 1
 } resource_type_enum_t;
 
+/**
+ * @name Helper Macros for virtual mailboxes flags manipulation.
+ */
+/**@{*/
+
+/**
+ * @brief Virtual mailboxes flags.
+ */
+#define VMAILBOX_STATUS_USED (1 << 0) /**< Used vmailbox? */
+
+/**
+ * @brief Asserts if the virtual mailbox is used.
+ */
+#define VMAILBOX_IS_USED(vmbxid) \
+	(virtual_mailboxes[vmbxid].status & VMAILBOX_STATUS_USED)
+/**@}*/
+
+/**
+ * @name Helper Macros for logic addresses operations.
+ */
+/**@{*/
+
+/**
+ * @brief Composes the logic address based on @p mbxid @p port.
+ */
+#define DO_LADDRESS_COMPOSE(mbxid, port) \
+	(mbxid * MAILBOX_PORT_NR + port)
+
+/**
+ * @brief Extracts mbxid and port from vmbxid.
+ */
+#define GET_LADDRESS_FD(vmbxid) \
+	(vmbxid / MAILBOX_PORT_NR)
+
+#define GET_LADDRESS_PORT(vmbxid) \
+	 (vmbxid % MAILBOX_PORT_NR)
+/**@}*/
+
+/**
+ * @name Helper Macros for ports status manipulation.
+ */
+/**@{*/
+
+/**
+ * @brief Mailbox ports flags.
+ */
+#define PORT_STATUS_USED (1 << 0) /**< Used port?   */
+
+/**
+ * @brief Asserts if the port of mbxid is used.
+ */
+#define PORT_IS_USED(mbxid,port) \
+	(active_mailboxes[mbxid].ports[port].status & PORT_STATUS_USED)
+/**@}*/
+
+/**
+ * @name Helper Macros for message buffers.
+ */
+/**@{*/
+
+/**
+ * @brief Message buffers flags.
+ */
+#define MBUFFER_FLAGS_USED (1 << 0) /**< Used? */
+#define MBUFFER_FLAGS_BUSY (1 << 1) /**< Busy? */
+
+/**
+ * @brief Asserts if the message buffer is in use / busy.
+ */
+#define MBUFFER_IS_USED(mbufferid) \
+	(mailbox_message_buffers[mbufferid].flags & MBUFFER_FLAGS_USED)
+
+#define MBUFFER_IS_BUSY(mbufferid) \
+	(mailbox_message_buffers[mbufferid].flags & MBUFFER_FLAGS_BUSY)
+/**@}*/
+
+/**
+ * @name Helper Macros for mailboxes operations.
+ */
+/**@{*/
+
+/**
+ * @brief Asserts if the mailbox data buffer is busy.
+ */
+#define MAILBOX_IS_BUSY(mbxid) \
+	(active_mailboxes[mbxid].buffer->flags & MBUFFER_FLAGS_BUSY)
+
+/**
+ * @brief Sets the mailbox data buffer as busy / notbusy.
+ */
+#define MAILBOX_SET_BUSY(mbxid) \
+	(active_mailboxes[mbxid].buffer->flags |= MBUFFER_FLAGS_BUSY)
+
+#define MAILBOX_SET_NOTBUSY(mbxid) \
+	(active_mailboxes[mbxid].buffer->flags &= ~MBUFFER_FLAGS_BUSY)
+
+/**@}*/
+
 /*============================================================================*
  * Control Structures.                                                        *
  *============================================================================*/
+
+/**
+ * @brief Struct that represents a mailbox message buffer.
+ */
+struct mailbox_message_buffer
+{
+	unsigned short flags; /* Flags. */
+
+	/**
+	 * @brief Structure that holds a message.
+	 *
+	 * @note Parameters aside the data buffer must be included in header size
+	 * on include/nanvix/kernel/mailbox.h -> KMAILBOX_MESSAGE_HEADER_SIZE.
+	 */
+	struct mailbox_message
+	{
+		int dest; /* Data destination. */
+		char data[KMAILBOX_MESSAGE_SIZE];
+	} message;
+};
+
+struct mailbox_message_buffer mailbox_message_buffers[KMAILBOX_MESSAGE_BUFFERS_MAX] = {
+	[0 ... (KMAILBOX_MESSAGE_BUFFERS_MAX - 1)] = {
+		.message = {
+			.dest = KMAILBOX_MAX,
+			.data = {'\0'},
+		},
+	},
+};
+
+/**
+ * @brief Struct that represents a port abstraction.
+ */
+struct port
+{
+	unsigned short status;                  /* Port status.           */
+	struct mailbox_message_buffer *mbuffer; /* Kernel buffer pointer. */
+};
 
 /**
  * @brief Table of virtual mailboxes.
@@ -51,18 +187,22 @@ PRIVATE struct
 	 * @name Control Variables
 	 */
 	/**@{*/
-	int fd; /**< Index to table of active mailboxes. */
+	unsigned short status; /**< Status.         */
+	int remote;            /**< Remote address. */
 	/**@}*/
 
 	/**
 	 * @name Performance Statistics
 	 */
 	/**@{*/
-	size_t volume;   /**< Amount of data transferred. */
-	uint64_t latency;/**< Transfer latency.           */
+	size_t volume;    /**< Amount of data transferred. */
+	uint64_t latency; /**< Transfer latency.           */
 	/**@}*/
 } ALIGN(sizeof(dword_t)) virtual_mailboxes[KMAILBOX_MAX] = {
-	[0 ... (KMAILBOX_MAX - 1)] = { .fd = -1 },
+	[0 ... (KMAILBOX_MAX - 1)] = {
+		.status  =  0,
+		.remote = -1
+	},
 };
 
 /**
@@ -70,11 +210,21 @@ PRIVATE struct
  */
 PRIVATE struct mailbox
 {
-	struct resource resource;  /**< Underlying resource.        */
-	int refcount;              /**< References count.           */
-	int hwfd;                  /**< Underlying file descriptor. */
-	int nodenum;               /**< Target node number.         */
-} active_mailboxes[(MAILBOX_CREATE_MAX + MAILBOX_OPEN_MAX)];
+	struct resource resource;              /**< Underlying resource.        */
+	int refcount;                          /**< References count.           */
+	int hwfd;                              /**< Underlying file descriptor. */
+	int nodenum;                           /**< Target node number.         */
+	struct port ports[MAILBOX_PORT_NR];    /**< Logic ports.                */
+	struct mailbox_message_buffer *buffer; /**< Data Buffer resource.       */
+} active_mailboxes[(MAILBOX_CREATE_MAX + MAILBOX_OPEN_MAX)] = {
+	[0 ... (MAILBOX_CREATE_MAX + MAILBOX_OPEN_MAX - 1)] {
+		.ports[0 ... (MAILBOX_PORT_NR - 1)] = {
+			.status = 0,
+			.mbuffer = NULL,
+		},
+		.nodenum = -1,
+	},
+};
 
 /**
  * @brief Resource pool.
@@ -84,41 +234,147 @@ PRIVATE const struct resource_pool mbxpool = {
 };
 
 /*============================================================================*
- * do_vmailbox_is_valid()                                                     *
- *============================================================================*/
-
-/**
- * @brief Asserts whether or not a virtual mailbox ID is valid.
- *
- * @param mbxid ID of the Target Mailbox.
- *
- * @returns One if the mailboxID is valid, and false otherwise.
- */
-PRIVATE int do_vmailbox_is_valid(int mbxid)
-{
-	return WITHIN(mbxid, 0, KMAILBOX_MAX);
-}
-
-/*============================================================================*
  * do_vmailbox_alloc()                                                        *
  *============================================================================*/
 
 /**
  * @brief Searches for a free virtual mailbox.
  *
+ * @param mbxid Target mailbox ID.
+ * @param port  Target port number on @p mbxid.
+ *
  * @returns Upon successful completion, the index of the virtual
- * mailbox found is returned. Upon failure, a negative number is
- * returned instead.
+ * mailbox in virtual_mailboxes tab is returned. Upon failure,
+ * a negative number is returned instead.
  */
-PRIVATE int do_vmailbox_alloc(void)
+PRIVATE int do_vmailbox_alloc(int mbxid, int port)
 {
-	for (int i = 0; i < KMAILBOX_MAX; ++i)
+	int vmbxid = DO_LADDRESS_COMPOSE(mbxid, port);
+
+	if (VMAILBOX_IS_USED(vmbxid))
+		return (-1);
+
+	return (vmbxid);
+}
+
+/*============================================================================*
+ * do_port_alloc()                                                            *
+ *============================================================================*/
+
+/**
+ * @brief Searches for a free port on a HW mailbox.
+ *
+ * @param mbxid ID of the target HW mailbox.
+ *
+ * @returns Upon successful completion, the index of the available
+ * port is returned. Upon failure, a negative number is returned
+ * instead.
+ */
+PRIVATE int do_port_alloc(int mbxid)
+{
+	/* Checks if can exist an available port. */
+	if (active_mailboxes[mbxid].refcount == MAILBOX_PORT_NR)
+		goto error;
+
+	/* Searches for a free port on the target mailbox. */
+	for (unsigned int i = 0; i < MAILBOX_PORT_NR; ++i)
 	{
-		/* Found. */
-		if (virtual_mailboxes[i].fd < 0)
+		if (!PORT_IS_USED(mbxid, i))
 			return (i);
 	}
 
+error:
+	return (-1);
+}
+
+/*============================================================================*
+ * do_mbuffer_alloc()                                                         *
+ *============================================================================*/
+
+/**
+ * @brief Allocates a message buffer from message_buffers tab.
+ *
+ * @return Upon successful completion, the index of the allocated buffer
+ * on message_buffer tab is returned. Upon failure, a negative number is
+ * returned instead.
+ */
+PRIVATE int do_mbuffer_alloc(void)
+{
+	for (unsigned int i = 0; i < KMAILBOX_MESSAGE_BUFFERS_MAX; ++i)
+	{
+		if (!(MBUFFER_IS_USED(i) || MBUFFER_IS_BUSY(i)))
+		{
+			mailbox_message_buffers[i].flags |= MBUFFER_FLAGS_USED;
+
+			return (i);
+		}
+	}
+
+	return (-1);
+}
+
+/*============================================================================*
+ * do_mbuffer_free()                                                          *
+ *============================================================================*/
+
+/**
+ * @brief Releases a message buffer from message_buffers tab.
+ *
+ * @param buffer The target buffer to be freed.
+ *
+ * @return Upon successful completion, zero is returned. Upon failure,
+ * a negative number is returned instead.
+ */
+PRIVATE int do_mbuffer_free(struct mailbox_message_buffer * buffer)
+{
+	/* Bad mbuffer. */
+	if (buffer == NULL)
+		return (-EINVAL);
+
+	/* Buffer have data to be read. */
+	if (buffer->flags & MBUFFER_FLAGS_BUSY)
+		return (-EBUSY);
+
+	/* Resets mbuffer original status. */
+	buffer->flags = 0;
+	buffer->message.dest = KMAILBOX_MAX;
+	buffer->message.data[0] = '\0';
+
+	return (0);
+}
+
+/*============================================================================*
+ * do_message_search()                                                        *
+ *============================================================================*/
+
+/**
+ * @brief Searches for a stored message destinated to @p local_address.
+ *
+ * @param local_address Local HW address for which the messages come.
+ *
+ * @returns Upon successful completion, the mbuffer that contains the first
+ * message found is returned. A negative error number is returned instead.
+ */
+PRIVATE int do_message_search(int local_address)
+{
+	for (unsigned int i = 0; i < KMAILBOX_MESSAGE_BUFFERS_MAX; ++i)
+	{
+		/* Is the buffer being used by another mailbox? */
+		if (MBUFFER_IS_USED(i))
+			continue;
+
+		/* The buffer contains a stored message? */
+		if (!MBUFFER_IS_BUSY(i))
+			continue;
+
+		/* Is this message addressed to the local_address? */
+		if (mailbox_message_buffers[i].message.dest != local_address)
+			continue;
+
+		return (i);
+	}
+
+	/* No message encountered. */
 	return (-1);
 }
 
@@ -145,7 +401,7 @@ PRIVATE int do_vmailbox_alloc(void)
 /**@}*/
 
 /**
- * @brief Searches for a mailbox.
+ * @brief Searches for an active HW mailbox.
  *
  * Searches for a mailbox in the table of active mailboxes.
  *
@@ -193,20 +449,29 @@ PRIVATE int do_mailbox_search(int nodenum, enum mailbox_search_type search_type)
  */
 PRIVATE int _do_mailbox_create(int local)
 {
-	int hwfd;  /* File descriptor. */
-	int mbxid; /* Mailbox ID.      */
+	int hwfd;    /* File descriptor.      */
+	int mbxid;   /* Mailbox ID.           */
+	int mbuffer; /* Allocated mbuffer ID. */
 
 	/* Search target hardware mailbox. */
 	if ((mbxid = do_mailbox_search(local, MAILBOX_SEARCH_INPUT)) >= 0)
 		return (mbxid);
 
+	/* Allocate data buffer. */
+	if ((mbuffer = do_mbuffer_alloc()) < 0)
+		return (-EAGAIN);
+
 	/* Allocate resource. */
 	if ((mbxid = resource_alloc(&mbxpool)) < 0)
+	{
+		do_mbuffer_free(&mailbox_message_buffers[mbuffer]);
 		return (-EAGAIN);
+	}
 
 	/* Create underlying input hardware mailbox. */
 	if ((hwfd = mailbox_create(local)) < 0)
 	{
+		do_mbuffer_free(&mailbox_message_buffers[mbuffer]);
 		resource_free(&mbxpool, mbxid);
 		return (hwfd);
 	}
@@ -215,6 +480,7 @@ PRIVATE int _do_mailbox_create(int local)
 	active_mailboxes[mbxid].hwfd     = hwfd;
 	active_mailboxes[mbxid].refcount = 0;
 	active_mailboxes[mbxid].nodenum  = local;
+	active_mailboxes[mbxid].buffer   = &mailbox_message_buffers[mbuffer];
 	resource_set_rdonly(&active_mailboxes[mbxid].resource);
 	resource_set_notbusy(&active_mailboxes[mbxid].resource);
 
@@ -225,28 +491,30 @@ PRIVATE int _do_mailbox_create(int local)
  * @brief Creates a virtual mailbox.
  *
  * @param local Logic ID of the target local node.
+ * @param port  Target port in @p local node.
  *
  * @returns Upon successful completion, the ID of the newly created
  * virtual mailbox is returned. Upon failure, a negative error code
  * is returned instead.
  */
-PUBLIC int do_vmailbox_create(int local)
+PUBLIC int do_vmailbox_create(int local, int port)
 {
 	int mbxid;  /* Hardware mailbox ID. */
 	int vmbxid; /* Virtual mailbox ID.  */
-
-	/* Allocate a virtual mailbox. */
-	if ((vmbxid = do_vmailbox_alloc()) < 0)
-		return (-EAGAIN);
 
 	/* Create hardware mailbox. */
 	if ((mbxid = _do_mailbox_create(local)) < 0)
 		return (mbxid);
 
+	/* Allocate a virtual mailbox. */
+	if ((vmbxid = do_vmailbox_alloc(mbxid, port)) < 0)
+		return (-EBUSY);
+
 	/* Initialize virtual mailbox. */
-	virtual_mailboxes[vmbxid].fd      = mbxid;
+	virtual_mailboxes[vmbxid].status |= VMAILBOX_STATUS_USED;
 	virtual_mailboxes[vmbxid].volume  = 0ULL;
 	virtual_mailboxes[vmbxid].latency = 0ULL;
+	active_mailboxes[mbxid].ports[port].status |= PORT_STATUS_USED;
 	active_mailboxes[mbxid].refcount++;
 
 	dcache_invalidate();
@@ -299,29 +567,37 @@ PRIVATE int _do_mailbox_open(int remote)
 /**
  * @brief Opens a virtual mailbox.
  *
- * @param remote Logic ID of the target remote node.
+ * @param remote      Logic ID of the target remote node.
+ * @param remote_port Target port in @p remote node.
  *
  * @returns Upon successful completion, the ID of the newly opened
  * virtual mailbox is returned. Upon failure, a negative error code
  * is returned instead.
  */
-PUBLIC int do_vmailbox_open(int remote)
+PUBLIC int do_vmailbox_open(int remote, int remote_port)
 {
-	int mbxid;  /* Hardware mailbox ID. */
-	int vmbxid; /* Virtual mailbox ID.  */
-
-	/* Allocate a virtual mailbox. */
-	if ((vmbxid = do_vmailbox_alloc()) < 0)
-		return (-EAGAIN);
+	int mbxid;  /* Hardware mailbox ID.          */
+	int vmbxid; /* Virtual mailbox ID.           */
+	int port;   /* Port allocated in local node. */
 
 	/* Create hardware mailbox. */
 	if ((mbxid = _do_mailbox_open(remote)) < 0)
 		return (mbxid);
 
+	/* Allocates a free port in the HW mailbox. */
+	if ((port = do_port_alloc(mbxid)) < 0)
+		return (-EAGAIN);
+
+	/* Allocate a virtual mailbox. */
+	if ((vmbxid = do_vmailbox_alloc(mbxid, port)) < 0)
+		return (-EBUSY);
+
 	/* Initialize virtual mailbox. */
-	virtual_mailboxes[vmbxid].fd       = mbxid;
-	virtual_mailboxes[vmbxid].volume   = 0ULL;
-	virtual_mailboxes[vmbxid].latency  = 0ULL;
+	virtual_mailboxes[vmbxid].status |= VMAILBOX_STATUS_USED;
+	virtual_mailboxes[vmbxid].volume  = 0ULL;
+	virtual_mailboxes[vmbxid].latency = 0ULL;
+	virtual_mailboxes[vmbxid].remote  = DO_LADDRESS_COMPOSE(remote, remote_port);
+	active_mailboxes[mbxid].ports[port].status |= PORT_STATUS_USED;
 	active_mailboxes[mbxid].refcount++;
 
 	dcache_invalidate();
@@ -343,7 +619,14 @@ PUBLIC int do_vmailbox_open(int remote)
  */
 PRIVATE int _do_mailbox_release(int mbxid, int (*release_fn)(int))
 {
-	int ret;
+	int ret; /* HAL function return. */
+
+	/* Check if there is a data buffer allocated. */
+	if (active_mailboxes[mbxid].buffer != NULL)
+	{
+		if ((ret = do_mbuffer_free(active_mailboxes[mbxid].buffer)) < 0)
+			return (ret);
+	}
 
 	if ((ret = release_fn(active_mailboxes[mbxid].hwfd)) < 0)
 		return (ret);
@@ -370,24 +653,36 @@ PRIVATE int _do_mailbox_release(int mbxid, int (*release_fn)(int))
  */
 PUBLIC int do_vmailbox_unlink(int mbxid)
 {
-	int fd; /* Active_mailboxes table index. */
-
-	/* Invalid virtual mailbox. */
-	if (!do_vmailbox_is_valid(mbxid))
-		return (-EINVAL);
-
-	fd = virtual_mailboxes[mbxid].fd;
+	int fd;              /* Active mailbox logic ID. */
+	int port;            /* Vmbx logic port ID.      */
+	int local_hwaddress; /* Local HW address.        */
+	int mbuffer;         /* Busy mbuffer.            */
 
 	/* Bad virtual mailbox. */
+	if (!VMAILBOX_IS_USED(mbxid))
+		return (-EBADF);
+
+	fd = GET_LADDRESS_FD(mbxid);
+
+	/* Bad mailbox. */
 	if (!resource_is_used(&active_mailboxes[fd].resource))
 		return (-EBADF);
 
-	/* Bad virtual mailbox. */
+	/* Bad mailbox. */
 	if (!resource_is_readable(&active_mailboxes[fd].resource))
 		return (-EBADF);
 
+	port = GET_LADDRESS_PORT(mbxid);
+
+	local_hwaddress = DO_LADDRESS_COMPOSE(active_mailboxes[fd].nodenum, port);
+
+	/* Check if exist pending messages for this port. */
+	if ((mbuffer = do_message_search(local_hwaddress)) >= 0)
+		return (-EBUSY);
+
 	/* Unlink virtual mailbox. */
-	virtual_mailboxes[mbxid].fd = -1;
+	virtual_mailboxes[mbxid].status = 0;
+	active_mailboxes[fd].ports[port].status &= ~PORT_STATUS_USED;
 	active_mailboxes[fd].refcount--;
 
 	/* Release underlying hardware mailbox. */
@@ -411,24 +706,29 @@ PUBLIC int do_vmailbox_unlink(int mbxid)
  */
 PUBLIC int do_vmailbox_close(int mbxid)
 {
-	int fd; /* Active_mailboxes table index. */
-
-	/* Invalid virtual mailbox. */
-	if (!do_vmailbox_is_valid(mbxid))
-		return (-EINVAL);
-
-	fd = virtual_mailboxes[mbxid].fd;
+	int fd;   /* Active mailbox logic ID.       */
+	int port; /* Virtual mailbox logic port ID. */
 
 	/* Bad virtual mailbox. */
+	if (!VMAILBOX_IS_USED(mbxid))
+		return (-EBADF);
+
+	fd = GET_LADDRESS_FD(mbxid);
+
+	/* Bad mailbox. */
 	if (!resource_is_used(&active_mailboxes[fd].resource))
 		return (-EBADF);
 
-	/* Bad virtual mailbox. */
+	/* Bad mailbox. */
 	if (!resource_is_writable(&active_mailboxes[fd].resource))
 		return (-EBADF);
 
-	/* Unlink hardware mailbox. */
-	virtual_mailboxes[mbxid].fd = -1;
+	port = GET_LADDRESS_PORT(mbxid);
+
+	/* Unlink virtual mailbox. */
+	virtual_mailboxes[mbxid].status &= ~VMAILBOX_STATUS_USED;
+	virtual_mailboxes[mbxid].remote = -1;
+	active_mailboxes[fd].ports[port].status &= ~PORT_STATUS_USED;
 	active_mailboxes[fd].refcount--;
 
 	/* Release underlying hardware mailbox. */
@@ -443,43 +743,153 @@ PUBLIC int do_vmailbox_close(int mbxid)
  *============================================================================*/
 
 /**
+ * @brief Allocs a new message buffer and store the old
+ * on message_buffers tab.
+ *
+ * @param fd Busy HW mailbox.
+ *
+ * @returns Upon successful completion, zero is returned.
+ * A negative error number is returned instead.
+ */
+PRIVATE int do_message_store(int fd)
+{
+	int dest;    /* Message destination.   */
+	int port;    /* Target port.           */
+	int mbuffer; /* New mbuffer allocated. */
+
+	dest = active_mailboxes[fd].buffer->message.dest;
+	port = GET_LADDRESS_PORT(dest);
+
+	/* Check if the destination port is opened to receive data. */
+	if (PORT_IS_USED(fd, port))
+	{
+		/* Allocate a message_buffer to hold the message. */
+		if ((mbuffer = do_mbuffer_alloc()) < 0)
+			return (-EBUSY);
+
+		/* Switch the mailbox buffer to use an empty one. */
+		active_mailboxes[fd].buffer->flags &= ~MBUFFER_FLAGS_USED;
+		active_mailboxes[fd].buffer = &mailbox_message_buffers[mbuffer];
+	}
+	/**
+	 * XXX - ELSE Discards the message.
+	 */
+
+	return (0);
+}
+
+/**
  * @todo TODO: Provide a detailed description for this function.
  */
 PUBLIC int do_vmailbox_aread(int mbxid, void *buffer, size_t size)
 {
-	int ret;     /* HAL function return.                     */
-	int fd;      /* Active mailbox index of virtual mailbox. */
-	uint64_t t1; /* Clock value before aread call.           */
-	uint64_t t2; /* Clock value after aread call.            */
-
-	/* Invalid virtual mailbox. */
-	if (!do_vmailbox_is_valid(mbxid))
-		return (-EINVAL);
-
-	fd = virtual_mailboxes[mbxid].fd;
+	int ret;             /* HAL function return.           */
+	int fd;              /* HW mailbox logic index.        */
+	int port;            /* Port used by vmailbox.         */
+	int dest;            /* Msg destination address.       */
+	int local_hwaddress; /* Vmailbox hardware address.     */
+	int mbuffer;         /* New alocated buffer.           */
+	struct mailbox_message_buffer *aux_buffer_ptr;
+	uint64_t t1;         /* Clock value before aread call. */
+	uint64_t t2;         /* Clock value after aread call.  */
 
 	/* Bad virtual mailbox. */
+	if (!VMAILBOX_IS_USED(mbxid))
+		return (-EBADF);
+
+	fd = GET_LADDRESS_FD(mbxid);
+
+	/* Bad mailbox. */
 	if (!resource_is_used(&active_mailboxes[fd].resource))
 		return (-EBADF);
 
-	/* Bad virtual mailbox. */
+	/* Bad mailbox. */
 	if (!resource_is_readable(&active_mailboxes[fd].resource))
 		return (-EBADF);
 
+	port = GET_LADDRESS_PORT(mbxid);
+
+	local_hwaddress = DO_LADDRESS_COMPOSE(active_mailboxes[fd].nodenum, port);
+
 	resource_set_async(&active_mailboxes[fd].resource);
+
+	/* Is there a pending message for this vmailbox? */
+	if ((mbuffer = do_message_search(local_hwaddress)) >= 0)
+	{
+		aux_buffer_ptr = &mailbox_message_buffers[mbuffer];
+
+		t1 = clock_read();
+			kmemcpy(buffer, (void *) &aux_buffer_ptr->message.data, ret = size);
+		t2 = clock_read();
+
+		aux_buffer_ptr->flags &= ~MBUFFER_FLAGS_BUSY;
+
+		/* Releases the message buffer. */
+		KASSERT(do_mbuffer_free(aux_buffer_ptr) == 0);
+
+		goto finish;
+	}
+
+	/* There is a pending read in HW mailbox data buffer. */
+	if (MAILBOX_IS_BUSY(fd))
+	{
+		dest = active_mailboxes[fd].buffer->message.dest;
+		if (dest == local_hwaddress) {
+			t1 = clock_read();
+				kmemcpy(buffer, (void *) &active_mailboxes[fd].buffer->message.data, ret = size);
+			t2 = clock_read();
+
+			goto unlock_mailbox;
+		}
+		else if ((ret = do_message_store(fd)) < 0)
+			return (ret);
+	}
+
+again:
+	/* Sets the mailbox data buffer as busy. */
+	MAILBOX_SET_BUSY(fd);
+
+	dcache_invalidate();
 
 	t1 = clock_read();
 
 		/* Setup asynchronous read. */
-		if ((ret = mailbox_aread(active_mailboxes[fd].hwfd, buffer, size)) < 0)
-			return (ret);
+		if ((ret = mailbox_aread(active_mailboxes[fd].hwfd, (void *) &active_mailboxes[fd].buffer->message, MAILBOX_MSG_SIZE)) < 0)
+			goto error;
+
+		if ((ret = mailbox_wait(active_mailboxes[fd].hwfd)) < 0)
+			goto error;
 
 	t2 = clock_read();
 
+	/* Checks if the message is addressed for the requesting port. */
+	dest = active_mailboxes[fd].buffer->message.dest;
+	if (dest != local_hwaddress)
+	{
+		if ((ret = do_message_store(fd)) < 0)
+			return (ret);
+
+		goto again;
+	}
+
+	ret = size;
+
+	kmemcpy(buffer, (void *) &active_mailboxes[fd].buffer->message.data, size);
+
+unlock_mailbox:
+	/* Sets the mailbox data buffer as not busy. */
+	MAILBOX_SET_NOTBUSY(fd);
+
+finish:
 	/* Update performance statistics. */
 	virtual_mailboxes[mbxid].latency += (t2 - t1);
 	virtual_mailboxes[mbxid].volume += ret;
 
+	dcache_invalidate();
+	return (ret);
+
+error:
+	MAILBOX_SET_NOTBUSY(fd);
 	return (ret);
 }
 
@@ -492,16 +902,18 @@ PUBLIC int do_vmailbox_aread(int mbxid, void *buffer, size_t size)
  */
 PUBLIC int do_vmailbox_awrite(int mbxid, const void * buffer, size_t size)
 {
-	int ret;     /* HAL function return.                     */
-	int fd;      /* Active mailbox index of virtual mailbox. */
-	uint64_t t1; /* Clock value before awrite call.          */
-	uint64_t t2; /* Clock value after awrite call.           */
+	int ret;     /* HAL function return.            */
+	int fd;      /* Hardware mailbox logic index.   */
+	int port;    /* HW port specified to vmailbox.  */
+	int mbuffer; /* Message buffer used to write.   */
+	uint64_t t1; /* Clock value before awrite call. */
+	uint64_t t2; /* Clock value after awrite call.  */
 
-	/* Invalid virtual mailbox. */
-	if (!do_vmailbox_is_valid(mbxid))
-		return (-EINVAL);
+	/* Bad virtual mailbox. */
+	if (!VMAILBOX_IS_USED(mbxid))
+		return (-EBADF);
 
-	fd = virtual_mailboxes[mbxid].fd;
+	fd = GET_LADDRESS_FD(mbxid);
 
 	/* Bad virtual mailbox. */
 	if (!resource_is_used(&active_mailboxes[fd].resource))
@@ -511,19 +923,43 @@ PUBLIC int do_vmailbox_awrite(int mbxid, const void * buffer, size_t size)
 	if (!resource_is_writable(&active_mailboxes[fd].resource))
 		return (-EBADF);
 
+	port = GET_LADDRESS_PORT(mbxid);
+
+	/* Allocate the message buffer that will be used to write. */
+	if (active_mailboxes[fd].ports[port].mbuffer != NULL)
+		goto write;
+
+	if ((mbuffer = do_mbuffer_alloc()) < 0)
+		return (mbuffer);
+
+	active_mailboxes[fd].ports[port].mbuffer = &mailbox_message_buffers[mbuffer];
+
 	resource_set_async(&active_mailboxes[fd].resource);
 
+	active_mailboxes[fd].ports[port].mbuffer->message.dest = virtual_mailboxes[mbxid].remote;
+	kmemcpy((void *) &active_mailboxes[fd].ports[port].mbuffer->message.data, buffer, size);
+
+write:
 	t1 = clock_read();
 
 		/* Setup asynchronous write. */
-		if ((ret = mailbox_awrite(active_mailboxes[fd].hwfd, buffer, size)) < 0)
+		if ((ret = mailbox_awrite(active_mailboxes[fd].hwfd, (void *) &active_mailboxes[fd].ports[port].mbuffer->message, MAILBOX_MSG_SIZE)) < 0)
+			return (ret);
+
+		if ((ret = mailbox_wait(active_mailboxes[fd].hwfd)) < 0)
 			return (ret);
 
 	t2 = clock_read();
 
+	ret = size;
+
 	/* Update performance statistics. */
 	virtual_mailboxes[mbxid].latency += (t2 - t1);
 	virtual_mailboxes[mbxid].volume += ret;
+
+	/* Releases the buffer allocated. */
+	do_mbuffer_free(active_mailboxes[fd].ports[port].mbuffer);
+	active_mailboxes[fd].ports[port].mbuffer = NULL;
 
 	return (ret);
 }
@@ -542,11 +978,11 @@ PUBLIC int do_vmailbox_wait(int mbxid)
 	uint64_t t1; /* Clock value before wait call.            */
 	uint64_t t2; /* Clock value after wait call.             */
 
-	/* Invalid virtual mailbox. */
-	if (!do_vmailbox_is_valid(mbxid))
-		return (-EINVAL);
+	/* Bad virtual mailbox. */
+	if (!VMAILBOX_IS_USED(mbxid))
+		return (-EBADF);
 
-	fd = virtual_mailboxes[mbxid].fd;
+	fd = GET_LADDRESS_FD(mbxid);
 
 	/* Bad virtual mailbox. */
 	if (!resource_is_async(&active_mailboxes[fd].resource))
@@ -578,13 +1014,16 @@ PUBLIC int do_vmailbox_wait(int mbxid)
 int do_vmailbox_ioctl(int mbxid, unsigned request, va_list args)
 {
 	int ret = 0;
-
-	/* Invalid virtual mailbox. */
-	if (!do_vmailbox_is_valid(mbxid))
-		return (-EINVAL);
+	int fd;
 
 	/* Bad virtual mailbox. */
-	if (!resource_is_used(&active_mailboxes[virtual_mailboxes[mbxid].fd].resource))
+	if (!VMAILBOX_IS_USED(mbxid))
+		return (-EBADF);
+
+	fd = GET_LADDRESS_FD(mbxid);
+
+	/* Bad virtual mailbox. */
+	if (!resource_is_used(&active_mailboxes[fd].resource))
 		return (-EBADF);
 
 	/* Parse request. */

--- a/src/kernel/sys/mailbox.c
+++ b/src/kernel/sys/mailbox.c
@@ -36,13 +36,17 @@
 /**
  * @see do_vmailbox_create().
  */
-PUBLIC int kernel_mailbox_create(int local)
+PUBLIC int kernel_mailbox_create(int local, int port)
 {
 	/* Invalid local ID. */
 	if (!WITHIN(local, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
 
-	return (do_vmailbox_create(local));
+	/* Invalid port number. */
+	if (!WITHIN(port, 0, MAILBOX_PORT_NR))
+		return (-EINVAL);
+
+	return (do_vmailbox_create(local, port));
 }
 
 /*============================================================================*
@@ -52,13 +56,17 @@ PUBLIC int kernel_mailbox_create(int local)
 /**
  * @see do_vmailbox_open().
  */
-PUBLIC int kernel_mailbox_open(int remote)
+PUBLIC int kernel_mailbox_open(int remote, int remote_port)
 {
 	/* Invalid remote ID. */
 	if (!WITHIN(remote, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
 
-	return (do_vmailbox_open(remote));
+	/* Invalid port number. */
+	if (!WITHIN(remote_port, 0, MAILBOX_PORT_NR))
+		return (-EINVAL);
+
+	return (do_vmailbox_open(remote, remote_port));
 }
 
 /*============================================================================*
@@ -71,7 +79,7 @@ PUBLIC int kernel_mailbox_open(int remote)
 PUBLIC int kernel_mailbox_unlink(int mbxid)
 {
 	/* Invalid mailbox ID. */
-	if (mbxid < 0)
+	if (!WITHIN(mbxid, 0, KMAILBOX_MAX))
 		return (-EINVAL);
 
 	return (do_vmailbox_unlink(mbxid));
@@ -87,7 +95,7 @@ PUBLIC int kernel_mailbox_unlink(int mbxid)
 PUBLIC int kernel_mailbox_close(int mbxid)
 {
 	/* Invalid mailbox ID. */
-	if (mbxid < 0)
+	if (!WITHIN(mbxid, 0, KMAILBOX_MAX))
 		return (-EINVAL);
 
 	return (do_vmailbox_close(mbxid));
@@ -103,11 +111,11 @@ PUBLIC int kernel_mailbox_close(int mbxid)
 PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
 {
 	/* Invalid mailbox ID. */
-	if (mbxid < 0)
+	if (!WITHIN(mbxid, 0, KMAILBOX_MAX))
 		return (-EINVAL);
 
 	/* Invalid write size. */
-	if (size != MAILBOX_MSG_SIZE)
+	if (size != KMAILBOX_MESSAGE_SIZE)
 		return (-EINVAL);
 
 	/* Invalid buffer. */
@@ -131,11 +139,11 @@ PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
 PUBLIC int kernel_mailbox_aread(int mbxid, void *buffer, size_t size)
 {
 	/* Invalid mailbox ID. */
-	if (mbxid < 0)
+	if (!WITHIN(mbxid, 0, KMAILBOX_MAX))
 		return (-EINVAL);
 
 	/* Invalid read size. */
-	if (size != MAILBOX_MSG_SIZE)
+	if (size != KMAILBOX_MESSAGE_SIZE)
 		return (-EINVAL);
 
 	/* Invalid buffer. */
@@ -159,7 +167,7 @@ PUBLIC int kernel_mailbox_aread(int mbxid, void *buffer, size_t size)
 PUBLIC int kernel_mailbox_wait(int mbxid)
 {
 	/* Invalid mailbox ID. */
-	if (mbxid < 0)
+	if (!WITHIN(mbxid, 0, KMAILBOX_MAX))
 		return (-EINVAL);
 
 	return (do_vmailbox_wait(mbxid));
@@ -177,7 +185,7 @@ PUBLIC int kernel_mailbox_ioctl(int mbxid, unsigned request, va_list *args)
 	int ret;
 
 	/* Invalid mailbox ID. */
-	if (mbxid < 0)
+	if (!WITHIN(mbxid, 0, KMAILBOX_MAX))
 		return (-EINVAL);
 
 	/* Bad args. */

--- a/src/kernel/sys/syscalls.c
+++ b/src/kernel/sys/syscalls.c
@@ -172,13 +172,15 @@ PUBLIC void do_kcall2(void)
 #if __TARGET_HAS_MAILBOX
 			case NR_mailbox_create:
 				ret = kernel_mailbox_create(
-					(int) sysboard[coreid].arg0
+					(int) sysboard[coreid].arg0,
+					(int) sysboard[coreid].arg1
 				);
 				break;
 
 			case NR_mailbox_open:
 				ret = kernel_mailbox_open(
-					(int) sysboard[coreid].arg0
+					(int) sysboard[coreid].arg0,
+					(int) sysboard[coreid].arg1
 				);
 				break;
 


### PR DESCRIPTION
# Description #
In this PR was implemented the correct addressing scheme of messages to different Virtual Mailboxes, based on ports vinculated to the HW mailboxes.
Below were list some noticeable changes.

#### Mailbox Interface Changes ####
- Added `port` parameter on `do_vmailbox_create(int local, int port)` signature;
- Added `remote_port` parameter on `do_vmailbox_open(int remote, int remote_port)`;

#### Mailbox Abstraction ####
- `KMAILBOX_MESSAGE_SIZE` is the new mailbox size constant that defines the mailbox message size. It considers the `MAILBOX_MSG_SIZE` exported by the Hal, and subtracts the Kernel header size.

#### Small Bugfixes ####
- Added a `VMAILBOX_IS_USED` check before each kernel function that uses Vmailboxes IDs, to avoid operations using unused virtual mailboxes.

# Related Issues #
Closes #218 - [[ikc] Multiplex Mailbox Messages](https://github.com/nanvix/microkernel/issues/218)