### PR TITLE
Enhancement: Removes nodenum exchange

### DIFF
--- a/include/nanvix/kernel/syscall.h
+++ b/include/nanvix/kernel/syscall.h
@@ -68,45 +68,44 @@
 	#define NR_sigwait        13 /**< kernel_sigwait()        */
 	#define NR_sigreturn      14 /**< kernel_sigreturn()      */
 	#define NR_node_get_num   15 /**< kernel_node_get_num()   */
-	#define NR_node_set_num   16 /**< kernel_node_set_num()   */
-	#define NR_sync_create    17 /**< kernel_sync_create()    */
-	#define NR_sync_open      18 /**< kernel_sync_open()      */
-	#define NR_sync_wait      19 /**< kernel_sync_wait()      */
-	#define NR_sync_signal    20 /**< kernel_sync_signal()    */
-	#define NR_sync_close     21 /**< kernel_sync_close()     */
-	#define NR_sync_unlink    22 /**< kernel_sync_unlink()    */
-	#define NR_mailbox_create 23 /**< kernel_mailbox_create() */
-	#define NR_mailbox_open   24 /**< kernel_mailbox_open()   */
-	#define NR_mailbox_unlink 25 /**< kernel_mailbox_unlink() */
-	#define NR_mailbox_close  26 /**< kernel_mailbox_close()  */
-	#define NR_mailbox_awrite 27 /**< kernel_mailbox_awrite() */
-	#define NR_mailbox_aread  28 /**< kernel_mailbox_aread()  */
-	#define NR_mailbox_wait   29 /**< kernel_mailbox_wait()   */
-	#define NR_mailbox_ioctl  30 /**< kernel_mailbox_ioctl()  */
-	#define NR_portal_create  31 /**< kernel_portal_create()  */
-	#define NR_portal_allow   32 /**< kernel_portal_allow()   */
-	#define NR_portal_open    33 /**< kernel_portal_open()    */
-	#define NR_portal_unlink  34 /**< kernel_portal_unlink()  */
-	#define NR_portal_close   35 /**< kernel_portal_close()   */
-	#define NR_portal_awrite  36 /**< kernel_portal_awrite()  */
-	#define NR_portal_aread   37 /**< kernel_portal_aread()   */
-	#define NR_portal_wait    38 /**< kernel_portal_wait()    */
-	#define NR_portal_ioctl   39 /**< kernel_portal_ioctl()   */
-	#define NR_clock          40 /**< kernel_clock()          */
-	#define NR_stats          42 /**< kernel_stats()          */
-	#define NR_frame_alloc    43 /**< kernel_frame_alloc()    */
-	#define NR_frame_free     44 /**< kernel_frame_free()     */
-	#define NR_upage_alloc    45 /**< kernel_upage_alloc()    */
-	#define NR_upage_free     46 /**< kernel_upage_free()     */
-	#define NR_upage_map      47 /**< kernel_upage_map()      */
-	#define NR_upage_link     48 /**< kernel_upage_link()     */
-	#define NR_upage_unlink   49 /**< kernel_upage_unlink()   */
-	#define NR_upage_unmap    50 /**< kernel_upage_unmap()    */
-	#define NR_excp_ctrl      51 /**< kernel_excp_ctrl()      */
-	#define NR_excp_pause     52 /**< kernel_excp_pause()     */
-	#define NR_excp_resume    53 /**< kernel_excp_resume()    */
+	#define NR_sync_create    16 /**< kernel_sync_create()    */
+	#define NR_sync_open      17 /**< kernel_sync_open()      */
+	#define NR_sync_wait      18 /**< kernel_sync_wait()      */
+	#define NR_sync_signal    19 /**< kernel_sync_signal()    */
+	#define NR_sync_close     20 /**< kernel_sync_close()     */
+	#define NR_sync_unlink    21 /**< kernel_sync_unlink()    */
+	#define NR_mailbox_create 22 /**< kernel_mailbox_create() */
+	#define NR_mailbox_open   23 /**< kernel_mailbox_open()   */
+	#define NR_mailbox_unlink 24 /**< kernel_mailbox_unlink() */
+	#define NR_mailbox_close  25 /**< kernel_mailbox_close()  */
+	#define NR_mailbox_awrite 26 /**< kernel_mailbox_awrite() */
+	#define NR_mailbox_aread  27 /**< kernel_mailbox_aread()  */
+	#define NR_mailbox_wait   28 /**< kernel_mailbox_wait()   */
+	#define NR_mailbox_ioctl  29 /**< kernel_mailbox_ioctl()  */
+	#define NR_portal_create  30 /**< kernel_portal_create()  */
+	#define NR_portal_allow   31 /**< kernel_portal_allow()   */
+	#define NR_portal_open    32 /**< kernel_portal_open()    */
+	#define NR_portal_unlink  33 /**< kernel_portal_unlink()  */
+	#define NR_portal_close   34 /**< kernel_portal_close()   */
+	#define NR_portal_awrite  35 /**< kernel_portal_awrite()  */
+	#define NR_portal_aread   36 /**< kernel_portal_aread()   */
+	#define NR_portal_wait    37 /**< kernel_portal_wait()    */
+	#define NR_portal_ioctl   38 /**< kernel_portal_ioctl()   */
+	#define NR_clock          39 /**< kernel_clock()          */
+	#define NR_stats          40 /**< kernel_stats()          */
+	#define NR_frame_alloc    42 /**< kernel_frame_alloc()    */
+	#define NR_frame_free     43 /**< kernel_frame_free()     */
+	#define NR_upage_alloc    44 /**< kernel_upage_alloc()    */
+	#define NR_upage_free     45 /**< kernel_upage_free()     */
+	#define NR_upage_map      46 /**< kernel_upage_map()      */
+	#define NR_upage_link     47 /**< kernel_upage_link()     */
+	#define NR_upage_unlink   48 /**< kernel_upage_unlink()   */
+	#define NR_upage_unmap    49 /**< kernel_upage_unmap()    */
+	#define NR_excp_ctrl      50 /**< kernel_excp_ctrl()      */
+	#define NR_excp_pause     51 /**< kernel_excp_pause()     */
+	#define NR_excp_resume    52 /**< kernel_excp_resume()    */
 
-	#define NR_last_kcall     54 /**< NR_SYSCALLS definer     */
+	#define NR_last_kcall     53 /**< NR_SYSCALLS definer     */
 	/**@}*/
 
 /*============================================================================*
@@ -270,8 +269,7 @@
  * NoC Kernel Calls                                                           *
  *============================================================================*/
 
-	EXTERN int kernel_node_get_num(int);
-	EXTERN int kernel_node_set_num(int, int);
+	EXTERN int kernel_node_get_num(void);
 
 /*============================================================================*
  * Sync Kernel Calls                                                          *

--- a/src/kernel/noc/portal.c
+++ b/src/kernel/noc/portal.c
@@ -414,30 +414,6 @@ PRIVATE int do_message_search(int local_address, int remote_address)
 }
 
 /*============================================================================*
- * portal_nodenum_is_local()                                                  *
- *============================================================================*/
-
-/**
- * @brief Evaluates if the given nodenum is local to the cluster.
- *
- * @param nodenum Nodenum to be evaluated.
- *
- * @returns Non zero if @p nodenum is local to the current cluster. Zero is
- * returned instead.
- */
-PUBLIC int portal_nodenum_is_local(int nodenum)
-{
-	int local;
-
-	local = processor_node_get_num(core_get_id());
-
-	if (cluster_is_ccluster(cluster_get_num()))
-		return (nodenum == local);
-	else
-		return (WITHIN(nodenum, local, (local + (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM))));
-}
-
-/*============================================================================*
  * do_portal_search()                                                         *
  *============================================================================*/
 
@@ -556,7 +532,7 @@ PUBLIC int do_vportal_create(int local, int port)
 	int vportalid; /* Virtual portal ID.  */
 
 	/* Checks if the input portal is local. */
-	if (!portal_nodenum_is_local(local))
+	if (!node_is_local(local))
 		return (-EINVAL);
 
 	/* Search target hardware portal. */
@@ -650,7 +626,7 @@ PRIVATE int _do_portal_open(int local, int remote)
 	if (local == remote)
 	{
 		/* Asserts that @p local is local to the cluster. */
-		if (!portal_nodenum_is_local(local))
+		if (!node_is_local(local))
 			return (-EINVAL);
 	}
 	else
@@ -691,7 +667,7 @@ PUBLIC int do_vportal_open(int local, int remote, int remote_port)
 	int port;      /* Free port available. */
 
 	/* Checks if the portal sender is local. */
-	if (!portal_nodenum_is_local(local))
+	if (!node_is_local(local))
 		return (-EINVAL);
 
 	/* Search target hardware portal. */
@@ -1284,7 +1260,7 @@ PUBLIC void kportal_init(void)
 
 	kprintf("[kernel][noc] initializing the kportal facility");
 
-	local = processor_node_get_num(core_get_id());
+	local = processor_node_get_num();
 
 	/* Create the input portal. */
 	KASSERT(_do_portal_create(local) >= 0);

--- a/src/kernel/noc/sync.c
+++ b/src/kernel/noc/sync.c
@@ -700,40 +700,20 @@ PUBLIC int do_vsync_signal(int syncid)
 PUBLIC void ksync_init(void)
 {
 	int nodes[2];
-	int nodenum = processor_node_get_num(0);
+	int nodenum = processor_node_get_num();
 
 	kprintf("[kernel][noc] initializing the ksync facility");
 
-	if (cluster_is_iocluster(cluster_get_num()))
+	nodes[1] = nodenum;
+
+	/* Creates all sync interfaces. */
+	for (int i = 0; i < PROCESSOR_NOC_NODES_NUM; ++i)
 	{
-		for (int i = 0; i < PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM; ++i)
-		{
-			nodes[1] = nodenum + i;
+		if (i == nodes[1])
+			continue;
 
-			/* Creates all sync interfaces. */
-			for (int j = 0; j < PROCESSOR_NOC_NODES_NUM; ++j)
-			{
-				if (j == nodes[1])
-					continue;
-
-				nodes[0] = j;
-				KASSERT(_do_sync_create(nodes, 2, SYNC_ONE_TO_ALL) >= 0);
-			}
-		}
-	}
-	else
-	{
-		nodes[1] = nodenum;
-
-		/* Creates all sync interfaces. */
-		for (int i = 0; i < PROCESSOR_NOC_NODES_NUM; ++i)
-		{
-			if (i == nodes[1])
-				continue;
-
-			nodes[0] = i;
-			KASSERT(_do_sync_create(nodes, 2, SYNC_ONE_TO_ALL) >= 0);
-		}
+		nodes[0] = i;
+		KASSERT(_do_sync_create(nodes, 2, SYNC_ONE_TO_ALL) >= 0);
 	}
 }
 

--- a/src/kernel/sys/noc.c
+++ b/src/kernel/sys/noc.c
@@ -32,64 +32,16 @@
  * @brief The kernel_node_get_num() function gets the NoC Node Number attached
  * with the core.
  *
- * @param coreid Attached Core ID.
- *
  * @return Positive number with successfully get the node number, negative
  * otherwise.
  *
  * @author João Vicente Souto
  */
-PUBLIC int kernel_node_get_num(int coreid)
+PUBLIC int kernel_node_get_num(void)
 {
-	/* Invalid core ID. */
-	if (!WITHIN(coreid, 0, CORES_NUM))
-		return (-EINVAL);
-
 #if (PROCESSOR_HAS_NOC)
-
-    return (processor_node_get_num(coreid));
-
+    return (processor_node_get_num());
 #else
-
 	return (0);
-
-#endif /* PROCESSOR_HAS_NOC */
-}
-
-/*============================================================================*
- * kernel_node_set_num()                                                      *
- *============================================================================*/
-
-/**
- * @brief The kernel_node_set_num() function exchange the NoC Node Number
- * attached with the core.
- *
- * @param coreid  Attached Core ID.
- * @param nodenum New NoC Node Number.
- *
- * @return Zero if successfully exchange the node number, non zero otherwise.
- *
- * @author João Vicente Souto
- */
-PUBLIC int kernel_node_set_num(int coreid, int nodenum)
-{
-	/* Invalid core ID. */
-	if (!WITHIN(coreid, 0, CORES_NUM))
-		return (-EINVAL);
-
-#if (PROCESSOR_HAS_NOC)
-
-	/* Invalid NoC node number. */
-	if (!WITHIN(nodenum, 0, PROCESSOR_NOC_NODES_NUM))
-		return (-EINVAL);
-
-	return (processor_node_set_num(coreid, nodenum));
-
-#else
-
-	UNUSED(nodenum);
-
-	return (-ENOSYS);
-
 #endif /* PROCESSOR_HAS_NOC */
 }

--- a/src/kernel/sys/syscalls.c
+++ b/src/kernel/sys/syscalls.c
@@ -121,16 +121,7 @@ PUBLIC void do_kcall2(void)
 				break;
 
 			case NR_node_get_num:
-				ret = kernel_node_get_num(
-					(int) sysboard[coreid].arg0
-				);
-				break;
-
-			case NR_node_set_num:
-				ret = kernel_node_set_num(
-					(int) sysboard[coreid].arg0,
-					(int) sysboard[coreid].arg1
-				);
+				ret = kernel_node_get_num();
 				break;
 
 #if __TARGET_HAS_SYNC


### PR DESCRIPTION
In this PR, I remove the dependency of the coreid to get the local `nodenum`. Also, I remove the unnecessary `kernel_node_set_num` and its redundant code.