### PR TITLE
[kcall] Bad Semaphores Initialization of Syscall Table

### DIFF
--- a/include/nanvix/kernel/syscall.h
+++ b/include/nanvix/kernel/syscall.h
@@ -385,7 +385,20 @@
 	 */
 	EXTERN int kernel_excp_resume(void);
 
-#endif
+#endif /* (THREAD_MAX > 1) */
+
+#endif /* __NANVIX_MICROKERNEL */
+
+/*============================================================================*
+ * Initialization Calls                                                       *
+ *============================================================================*/
+
+#ifdef __NANVIX_MICROKERNEL
+
+	/**
+	 * @brief Initializes the Syscall system.
+	 */
+	EXTERN void syscall_init(void);
 
 #endif /* __NANVIX_MICROKERNEL */
 

--- a/src/kernel/init/main.c
+++ b/src/kernel/init/main.c
@@ -88,6 +88,7 @@ PUBLIC void kmain(int argc, const char *argv[])
 #endif
 	mm_init();
 	noc_init();
+	syscall_init();
 
 	kprintf("[kernel][dev] enabling hardware interrupts");
 	interrupts_enable();

--- a/src/kernel/sys/syscalls.c
+++ b/src/kernel/sys/syscalls.c
@@ -491,7 +491,6 @@ PUBLIC int do_kcall(
 			sysboard[coreid].arg4 = arg4;
 			sysboard[coreid].syscall_nr = syscall_nr;
 			sysboard[coreid].pending = 1;
-			semaphore_init(&sysboard[coreid].syssem, 0);
 
 			semaphore_up(&syssem);
 			semaphore_down(&sysboard[coreid].syssem);
@@ -514,4 +513,17 @@ PUBLIC int do_kcall(
 	}
 
 	return (ret);
+}
+
+/**
+ * @brief Initializes the Syscall system.
+ */
+PUBLIC void syscall_init(void)
+{
+	for (unsigned coreid = 0; coreid < CORES_NUM; ++coreid)
+	{
+		sysboard[coreid].syscall_nr = -1;
+		sysboard[coreid].pending    =  0;
+		semaphore_init(&sysboard[coreid].syssem, 0);
+	}
 }


### PR DESCRIPTION
In this PR, I add a function to initialize the syscall system because multiple init on a semaphore can introduce an undefined behavior on Unix.