### PR TITLE
[ikc] New Communicator Get_Port Kcall

### DIFF
--- a/include/nanvix/kernel/kernel.h
+++ b/include/nanvix/kernel/kernel.h
@@ -32,8 +32,6 @@
 	#include <nanvix/kernel/syscall.h>
 	#include <nanvix/kernel/mm.h>
 	#include <nanvix/kernel/thread.h>
-	#include <nanvix/kernel/sync.h>
-	#include <nanvix/kernel/mailbox.h>
-	#include <nanvix/kernel/portal.h>
+	#include <nanvix/kernel/noc.h>
 
 #endif /* NANVIX_KERNEL_KERNEL_H_ */

--- a/include/nanvix/kernel/mailbox.h
+++ b/include/nanvix/kernel/mailbox.h
@@ -181,6 +181,16 @@
 	EXTERN int do_vmailbox_ioctl(int mbxid, unsigned request, va_list args);
 
 	/**
+	 * @brief Gets the @p mbxid logic port.
+	 *
+	 * @param mbxid Target mailbox.
+	 *
+	 * @returns Upon successful completion, the logic port is returned.
+	 * Upon failure, a negative error code is returned instead.
+	 */
+	EXTERN int do_vmailbox_get_port(int mbxid);
+
+	/**
 	 * @brief Initializes the mailbox facility.
 	 */
 	EXTERN void kmailbox_init(void);

--- a/include/nanvix/kernel/noc.h
+++ b/include/nanvix/kernel/noc.h
@@ -30,6 +30,12 @@
 	#include <nanvix/kernel/sync.h>
 	#include <nanvix/kernel/mailbox.h>
 
+/**
+ * @brief Comm_type constants.
+ */
+#define COMM_TYPE_MAILBOX 1
+#define COMM_TYPE_PORTAL  2
+
 #ifdef __NANVIX_MICROKERNEL
 
 	/**

--- a/include/nanvix/kernel/portal.h
+++ b/include/nanvix/kernel/portal.h
@@ -188,6 +188,16 @@
 	EXTERN int do_vportal_ioctl(int portalid, unsigned request, va_list args);
 
 	/**
+	 * @brief Gets the @p portalid logic port.
+	 *
+	 * @param portalid Target portal.
+	 *
+	 * @returns Upon successful completion, the logic port is returned.
+	 * Upon failure, a negative error code is returned instead.
+	 */
+	EXTERN int do_vportal_get_port(int portalid);
+
+	/**
 	 * @brief Initializes the portal facility.
 	 */
 	EXTERN void kportal_init(void);

--- a/include/nanvix/kernel/syscall.h
+++ b/include/nanvix/kernel/syscall.h
@@ -105,8 +105,9 @@
 	#define NR_excp_pause      51 /**< kernel_excp_pause()      */
 	#define NR_excp_resume     52 /**< kernel_excp_resume()     */
 	#define NR_cluster_get_num 53 /**< kernel_cluster_get_num() */
+	#define NR_comm_get_port   54 /**< kernel_comm_get_port()   */
 
-	#define NR_last_kcall      54 /**< NR_SYSCALLS definer      */
+	#define NR_last_kcall      55 /**< NR_SYSCALLS definer      */
 	/**@}*/
 
 /*============================================================================*
@@ -272,6 +273,7 @@
 
 	EXTERN int kernel_node_get_num(void);
 	EXTERN int kernel_cluster_get_num(void);
+	EXTERN int kernel_comm_get_port(int, int);
 
 /*============================================================================*
  * Sync Kernel Calls                                                          *

--- a/src/kernel/noc/vmailbox.c
+++ b/src/kernel/noc/vmailbox.c
@@ -37,6 +37,14 @@
 
 #if __TARGET_HAS_MAILBOX
 
+/**
+ * @brief Extracts fd and port from mbxid.
+ */
+/**@{*/
+#define GET_LADDRESS_FD(mbxid)   (mbxid / MAILBOX_PORT_NR)
+#define GET_LADDRESS_PORT(mbxid) (mbxid % MAILBOX_PORT_NR)
+/**@}*/
+
 /*============================================================================*
  * Virtual mailbox structure                                                  *
  *============================================================================*/
@@ -289,6 +297,32 @@ int do_vmailbox_ioctl(int mbxid, unsigned request, va_list args)
 			args
 		)
 	);
+}
+
+/*============================================================================*
+ * do_vmailbox_get_port()                                                     *
+ *============================================================================*/
+
+/**
+ * @todo TODO: Provide a detailed description for this function.
+ */
+int do_vmailbox_get_port(int mbxid)
+{
+	int ret;
+
+	if (!WITHIN(mbxid, 0, KMAILBOX_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&virtual_mailboxes[mbxid].lock);
+
+		if (!resource_is_used(&virtual_mailboxes[mbxid].resource))
+			ret = (-EBADF);
+		else
+			ret = (GET_LADDRESS_PORT(virtual_mailboxes[mbxid].config.fd));
+
+	spinlock_unlock(&virtual_mailboxes[mbxid].lock);
+
+	return (ret);
 }
 
 /*============================================================================*

--- a/src/kernel/noc/vportal.c
+++ b/src/kernel/noc/vportal.c
@@ -36,6 +36,14 @@
 
 #if __TARGET_HAS_PORTAL
 
+/**
+ * @brief Extracts fd and port from portalid.
+ */
+/**@{*/
+#define GET_LADDRESS_FD(portalid)   (portalid / KPORTAL_PORT_NR)
+#define GET_LADDRESS_PORT(portalid) (portalid % KPORTAL_PORT_NR)
+/**@}*/
+
 /*============================================================================*
  * Virtual portal structure                                                   *
  *============================================================================*/
@@ -336,6 +344,32 @@ int do_vportal_ioctl(int portalid, unsigned request, va_list args)
 			args
 		)
 	);
+}
+
+/*============================================================================*
+ * do_vportal_get_port()                                                      *
+ *============================================================================*/
+
+/**
+ * @todo TODO: Provide a detailed description for this function.
+ */
+int do_vportal_get_port(int portalid)
+{
+	int ret;
+
+	if (!WITHIN(portalid, 0, KPORTAL_MAX))
+		return (-EINVAL);
+
+	spinlock_lock(&virtual_portals[portalid].lock);
+
+		if (!resource_is_used(&virtual_portals[portalid].resource))
+			ret = (-EBADF);
+		else
+			ret = (GET_LADDRESS_PORT(virtual_portals[portalid].config.fd));
+
+	spinlock_unlock(&virtual_portals[portalid].lock);
+
+	return (ret);
 }
 
 /*============================================================================*

--- a/src/kernel/sys/noc.c
+++ b/src/kernel/sys/noc.c
@@ -23,6 +23,7 @@
  */
 
 #include <nanvix/hal.h>
+#include <nanvix/kernel/noc.h>
 #include <posix/errno.h>
 
 /*============================================================================*
@@ -67,4 +68,35 @@ PUBLIC int kernel_cluster_get_num(void)
 #else
 	return (-ENOSYS);
 #endif /* PROCESSOR_IS_MULTICLUSTER */
+}
+
+/*============================================================================*
+ * kernel_comm_get_port()                                                     *
+ *============================================================================*/
+
+/**
+ * @brief Returns the virtual communicator logic port.
+ *
+ * @param id   Virtual communicator id.
+ * @param type Type of the communicator (MAILBOX ? PORTAL)
+ *
+ * @return Upon successful completion the logical port ID of the underlying
+ * communicator is returned. Upon failure, a negative error code is returned
+ * instead.
+ *
+ * @author João Fellipe Uller
+ */
+PUBLIC int kernel_comm_get_port(int id, int type)
+{
+#if (__TARGET_HAS_MAILBOX)
+	if (type == COMM_TYPE_MAILBOX)
+		return (do_vmailbox_get_port(id));
+#endif /* TARGET_HAS_MAILBOX */
+
+#if (__TARGET_HAS_PORTAL)
+	if (type == COMM_TYPE_PORTAL)
+		return (do_vportal_get_port(id));
+#endif /* TARGET_HAS_PORTAL */
+
+	return (-ENOSYS);
 }

--- a/src/kernel/sys/syscalls.c
+++ b/src/kernel/sys/syscalls.c
@@ -436,6 +436,13 @@ PUBLIC int do_kcall(
 			ret = 0;
 			break;
 
+		case NR_comm_get_port:
+			ret = kernel_comm_get_port(
+				(int) arg0,
+				(int) arg1
+			);
+			break;
+
 #if __TARGET_HAS_SYNC
 		case NR_sync_wait:
 			ret = kernel_sync_wait(


### PR DESCRIPTION
# Description #
This PR adds the `comm_get_port` kernel call, to attend the necessity of the upper layers on knowing the allocated port in a portal_open call.