### PR TITLE
[ikc] Enhancement: Active Fair Write

### DIFF
--- a/src/kernel/noc/active.h
+++ b/src/kernel/noc/active.h
@@ -46,7 +46,7 @@
 	 * @brief Resource flags.
 	 */
 	/**@{*/
-	#define ACTIVE_FLAGS_ALLOWED  ((RESOURCE_FLAGS_MAPPED) << 1) /**< Has it been allowed? */
+	#define ACTIVE_FLAGS_ALLOWED (1 << 0) /**< Has it been allowed? */
 	/**@}*/
 
 	/**
@@ -111,6 +111,7 @@
 		*/
 		struct resource resource; /**< Generic resource information. */
 
+		int flags;                /**< Auxiliar flags.               */
 		int hwfd;                 /**< Underlying file descriptor.   */
 		int local;                /**< Target node number.           */
 		int remote;               /**< Target node number.           */
@@ -157,7 +158,7 @@
 	 */
 	static inline void active_set_allowed(struct active * active)
 	{
-		active->resource.flags |= ACTIVE_FLAGS_ALLOWED;
+		active->flags |= ACTIVE_FLAGS_ALLOWED;
 	}
 
 	/**
@@ -167,7 +168,7 @@
 	 */
 	static inline void active_set_notallowed(struct active * active)
 	{
-		active->resource.flags &= ~ACTIVE_FLAGS_ALLOWED;
+		active->flags &= ~ACTIVE_FLAGS_ALLOWED;
 	}
 
 	/**
@@ -179,7 +180,7 @@
 	 */
 	static inline int active_is_allowed(const struct active * active)
 	{
-		return (active->resource.flags & ACTIVE_FLAGS_ALLOWED);
+		return (active->flags & ACTIVE_FLAGS_ALLOWED);
 	}
 
 #endif /* NANVIX_NOC_ACTIVE_H_ */

--- a/src/kernel/noc/active.h
+++ b/src/kernel/noc/active.h
@@ -39,6 +39,7 @@
 	#include <posix/stdarg.h>
 
 	#include "mbuffer.h"
+	#include "port.h"
 	#include "communicator.h"
 
 	/**
@@ -89,30 +90,20 @@
     /**@}*/
 
 	/**
-	* @brief Struct that represents a port abstraction.
-	*/
-	struct port
+	 * @brief Circular FIFO to hold write requests.
+	 */
+	struct requests_fifo
 	{
-		/*
-		* XXX: Don't Touch! This Must Come First!
-		*/
-		struct resource resource; /**< Generic resource information. */
-
-		/**
-		* @brief Operation Variables
-		*/
-		short mbufferid; /* Kernel mbufferid. */
-	};
-
-	struct port_pool
-	{
-		struct port * ports; /**< Pool of ports.   */
-		const int nports;    /**< Number of ports. */
+		short head;         /**< Index of the first element. */
+		short tail;         /**< Index of the last element.  */
+		short max_capacity; /**< Max number of elements.     */
+		short nelements;    /**< Nr of elements in the fifo. */
+		short * fifo;       /**< Buffer to store elements.   */
 	};
 
 	/**
-	* @brief Table of active mailboxes.
-	*/
+	 * @brief Table of active mailboxes.
+	 */
 	struct active
 	{
 		/*
@@ -129,6 +120,7 @@
 
 		struct port_pool portpool;
 		struct mbuffer_pool * mbufferpool;
+		struct requests_fifo requests;
 	
 		const hw_create_fn do_create;
 		const hw_open_fn do_open;

--- a/src/kernel/noc/communicator.c
+++ b/src/kernel/noc/communicator.c
@@ -45,6 +45,8 @@ PUBLIC int communicator_alloc(
 {
 	struct communicator * comm;
 
+	KASSERT(pool != NULL);
+
 	/* Search for a free synchronization point. */
 	for (int i = 0; i < pool->ncommunicators; i++)
 	{
@@ -56,6 +58,7 @@ PUBLIC int communicator_alloc(
 			if (!resource_is_used(&comm->resource))
 			{
 				comm->resource = RESOURCE_INITIALIZER;
+				comm->flags    = 0;
 				comm->config   = *config;
 				comm->stats    = (struct pstats){0ULL, 0ULL};
 
@@ -100,6 +103,9 @@ PUBLIC int communicator_free(
 {
     int ret; /* Function return. */
 	struct communicator * comm;
+
+	KASSERT(pool != NULL);
+	KASSERT(WITHIN(id, 0, pool->ncommunicators));
 
 	comm = &pool->communicators[id];
 
@@ -152,6 +158,8 @@ PUBLIC ssize_t communicator_operate(
 )
 {
 	ssize_t ret; /* Return value. */
+
+	KASSERT(comm != NULL);
 
 	spinlock_lock(&comm->lock);
 
@@ -229,6 +237,8 @@ PUBLIC int communicator_wait(
 {
 	int ret; /* Return value. */
 
+	KASSERT(comm != NULL);
+
 	spinlock_lock(&comm->lock);
 
 		/* Bad communicator. */
@@ -291,6 +301,8 @@ PUBLIC int communicator_ioctl(
 )
 {
 	int ret; /* Return value. */
+
+	KASSERT(comm != NULL);
 
 	spinlock_lock(&comm->lock);
 

--- a/src/kernel/noc/communicator.h
+++ b/src/kernel/noc/communicator.h
@@ -43,8 +43,8 @@
 	 * @brief Resource flags.
 	 */
 	/**@{*/
-	#define COMMUNICATOR_FLAGS_FINISHED ((RESOURCE_FLAGS_MAPPED) << 1) /**< Has it finished?     */
-	#define COMMUNICATOR_FLAGS_ALLOWED  ((RESOURCE_FLAGS_MAPPED) << 2) /**< Has it been allowed? */
+	#define COMMUNICATOR_FLAGS_FINISHED (1 << 0) /**< Has it finished?     */
+	#define COMMUNICATOR_FLAGS_ALLOWED  (1 << 1) /**< Has it been allowed? */
 	/**@}*/
 
     #define COMM_IOCTL_GET_VOLUME  (MAILBOX_IOCTL_GET_VOLUME)
@@ -88,6 +88,7 @@
          */
         struct resource resource;  /**< Generic resource information.            */
 
+        int flags;                 /**< Auxiliar flags.                          */
         struct comm_config config; /**< Communicaton configuration.              */
         struct pstats stats;       /**< Performance Statistics.                  */
 
@@ -125,7 +126,7 @@
 	 */
 	static inline void communicator_set_finished(struct communicator *comm)
 	{
-		comm->resource.flags |= COMMUNICATOR_FLAGS_FINISHED;
+		comm->flags |= COMMUNICATOR_FLAGS_FINISHED;
 	}
 
 	/**
@@ -135,7 +136,7 @@
 	 */
 	static inline void communicator_set_notfinished(struct communicator *comm)
 	{
-		comm->resource.flags &= ~COMMUNICATOR_FLAGS_FINISHED;
+		comm->flags &= ~COMMUNICATOR_FLAGS_FINISHED;
 	}
 
     /**
@@ -145,7 +146,7 @@
 	 */
 	static inline void communicator_set_allowed(struct communicator *comm)
 	{
-		comm->resource.flags |= COMMUNICATOR_FLAGS_ALLOWED;
+		comm->flags |= COMMUNICATOR_FLAGS_ALLOWED;
 	}
 
 	/**
@@ -155,7 +156,7 @@
 	 */
 	static inline void communicator_set_notallowed(struct communicator *comm)
 	{
-		comm->resource.flags &= ~COMMUNICATOR_FLAGS_ALLOWED;
+		comm->flags &= ~COMMUNICATOR_FLAGS_ALLOWED;
 	}
 
     /**
@@ -167,7 +168,7 @@
 	 */
 	static inline int communicator_is_finished(const struct communicator *comm)
 	{
-		return (comm->resource.flags & COMMUNICATOR_FLAGS_FINISHED);
+		return (comm->flags & COMMUNICATOR_FLAGS_FINISHED);
 	}
 
 	/**
@@ -179,7 +180,7 @@
 	 */
 	static inline int communicator_is_allowed(const struct communicator *comm)
 	{
-		return (comm->resource.flags & COMMUNICATOR_FLAGS_ALLOWED);
+		return (comm->flags & COMMUNICATOR_FLAGS_ALLOWED);
 	}
 
 #endif /* NANVIX_NOC_COMMUNICATOR_H_ */

--- a/src/kernel/noc/mbuffer.c
+++ b/src/kernel/noc/mbuffer.c
@@ -51,6 +51,7 @@ PUBLIC int mbuffer_alloc(struct mbuffer_pool * pool)
 	int n = pool->nmbuffers;
 	size_t size = pool->mbuffer_size;
 
+	KASSERT(pool != NULL);
 	ret = (-EINVAL);
 
 	spinlock_lock(&pool->lock);
@@ -96,11 +97,16 @@ PUBLIC int mbuffer_alloc(struct mbuffer_pool * pool)
  */
 PUBLIC int mbuffer_release(struct mbuffer_pool * pool, int id, int keep_msg)
 {
-	char *base = (char *) pool->mbuffers;
-	size_t size = pool->mbuffer_size;
+	char * base;
+	size_t size;
 	struct mbuffer * buf;
 
-	buf = (struct mbuffer *)(&base[mult(id, size)]);
+	KASSERT(pool != NULL);
+	KASSERT(WITHIN(id, 0, pool->nmbuffers));
+
+	base = (char *) pool->mbuffers;
+	size = pool->mbuffer_size;
+	buf  = (struct mbuffer *)(&base[mult(id, size)]);
 
 	spinlock_lock(&pool->lock);
 
@@ -143,11 +149,16 @@ PUBLIC int mbuffer_release(struct mbuffer_pool * pool, int id, int keep_msg)
 PUBLIC int mbuffer_search(struct mbuffer_pool * pool, int dest, int src)
 {
 	int ret;
-	char *base = (char *) pool->mbuffers;
-	int n = pool->nmbuffers;
-	size_t size = pool->mbuffer_size;
+	char * base;
+	int n;
+	size_t size;
 
-	ret = (-EINVAL);
+	KASSERT(pool != NULL);
+
+	base = (char *) pool->mbuffers;
+	n    = pool->nmbuffers;
+	size = pool->mbuffer_size;
+	ret  = (-EINVAL);
 
 	/* Locks the mbuffers table. */
 	spinlock_lock(&pool->lock);
@@ -186,8 +197,14 @@ PUBLIC int mbuffer_search(struct mbuffer_pool * pool, int dest, int src)
 
 PUBLIC struct mbuffer * mbuffer_get(struct mbuffer_pool * pool, int id)
 {
-	char *base = (char *) pool->mbuffers;
-	size_t size = pool->mbuffer_size;
+	char * base;
+	size_t size;
+
+	KASSERT(pool != NULL);
+	KASSERT(WITHIN(id, 0, pool->nmbuffers));
+
+	base = (char *) pool->mbuffers;
+	size = pool->mbuffer_size;
 
 	return (struct mbuffer *)(&base[mult(id, size)]);
 }

--- a/src/kernel/noc/port.c
+++ b/src/kernel/noc/port.c
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* Must come first. */
+#define __NEED_RESOURCE
+
+#include <nanvix/hal.h>
+#include <nanvix/hlib.h>
+#include <posix/errno.h>
+#include <posix/stdarg.h>
+
+#include "port.h"
+
+/*============================================================================*
+ * portpool_choose_port()                                                       *
+ *============================================================================*/
+
+/**
+ * @brief Searches for a free port on @p fd.
+ *
+ * @param fd ID of the target HW mailbox.
+ *
+ * @returns Upon successful completion, the index of the available port is
+ * returned. A negative number is returned instead.
+ */
+PUBLIC int portpool_choose_port(const struct port_pool * pool)
+{
+	int ret; /* Return value. */
+
+	ret = (-EINVAL);
+
+	/* Checks if can exist an available port. */
+	if (pool->used_ports < pool->nports)
+	{
+		/* Searches for a free port on the target mailbox. */
+		for (int i = 0; i < pool->nports; ++i)
+		{
+			if (resource_is_used(&pool->ports[i].resource))
+				continue;
+
+			ret = i;
+			break;
+		}
+	}
+
+	return (ret);
+}

--- a/src/kernel/noc/port.c
+++ b/src/kernel/noc/port.c
@@ -47,7 +47,8 @@
 PUBLIC int portpool_choose_port(const struct port_pool * pool)
 {
 	int ret; /* Return value. */
-
+	
+	KASSERT(pool != NULL);
 	ret = (-EINVAL);
 
 	/* Checks if can exist an available port. */

--- a/src/kernel/noc/port.h
+++ b/src/kernel/noc/port.h
@@ -1,0 +1,104 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_NOC_PORT_H_
+#define NANVIX_NOC_PORT_H_
+
+	#include <nanvix/hal.h>
+	#include <nanvix/hlib.h>
+	#include <nanvix/const.h>
+	#include <posix/errno.h>
+	#include <posix/stdarg.h>
+
+	/**
+	 * @brief Resource flags.
+	 */
+	/**@{*/
+	#define PORT_FLAGS_REQUESTED ((RESOURCE_FLAGS_MAPPED) << 1) /**< Has it requested an op? */
+	/**@}*/
+
+   /*============================================================================*
+	* Control Structures.                                                        *
+	*============================================================================*/
+
+	/**
+	* @brief Struct that represents a port abstraction.
+	*/
+	struct port
+	{
+		/*
+		* XXX: Don't Touch! This Must Come First!
+		*/
+		struct resource resource; /**< Generic resource information. */
+
+		/**
+		* @brief Operation Variables
+		*/
+		short mbufferid; /* Kernel mbufferid. */
+	};
+
+	struct port_pool
+	{
+		struct port * ports; /**< Pool of ports.      */
+		const int nports;    /**< Number of ports.    */
+		int used_ports;      /**< Nr of ports in use. */
+	};
+
+	PUBLIC int portpool_choose_port(const struct port_pool *);
+
+    /**
+	 * @brief Sets a port as requested.
+	 *
+	 * @param port Target port.
+	 */
+	static inline void port_set_requested(struct port * port)
+	{
+		port->resource.flags |= PORT_FLAGS_REQUESTED;
+	}
+
+	/**
+	 * @brief Sets a port as not requested.
+	 *
+	 * @param port Target port.
+	 */
+	static inline void port_set_notrequested(struct port * port)
+	{
+		port->resource.flags &= ~PORT_FLAGS_REQUESTED;
+	}
+
+	/**
+	 * @brief Asserts whether or not a port is requested.
+	 *
+	 * @param port Target port.
+	 *
+	 * @returns One if the target port is requested, and zero otherwise.
+	 */
+	static inline int port_is_requested(const struct port * port)
+	{
+		return (port->resource.flags & PORT_FLAGS_REQUESTED);
+	}
+
+#endif /* NANVIX_NOC_PORT_H_ */
+
+/**@}*/

--- a/src/kernel/noc/port.h
+++ b/src/kernel/noc/port.h
@@ -35,7 +35,7 @@
 	 * @brief Resource flags.
 	 */
 	/**@{*/
-	#define PORT_FLAGS_REQUESTED ((RESOURCE_FLAGS_MAPPED) << 1) /**< Has it requested an op? */
+	#define PORT_FLAGS_REQUESTED (1 << 0) /**< Has it requested an op? */
 	/**@}*/
 
    /*============================================================================*
@@ -52,10 +52,8 @@
 		*/
 		struct resource resource; /**< Generic resource information. */
 
-		/**
-		* @brief Operation Variables
-		*/
-		short mbufferid; /* Kernel mbufferid. */
+		short flags;              /* Auxiliar flags.                 */
+		short mbufferid;          /* Mbuffer id.                     */
 	};
 
 	struct port_pool
@@ -74,7 +72,7 @@
 	 */
 	static inline void port_set_requested(struct port * port)
 	{
-		port->resource.flags |= PORT_FLAGS_REQUESTED;
+		port->flags |= PORT_FLAGS_REQUESTED;
 	}
 
 	/**
@@ -84,7 +82,7 @@
 	 */
 	static inline void port_set_notrequested(struct port * port)
 	{
-		port->resource.flags &= ~PORT_FLAGS_REQUESTED;
+		port->flags &= ~PORT_FLAGS_REQUESTED;
 	}
 
 	/**
@@ -96,7 +94,7 @@
 	 */
 	static inline int port_is_requested(const struct port * port)
 	{
-		return (port->resource.flags & PORT_FLAGS_REQUESTED);
+		return (port->flags & PORT_FLAGS_REQUESTED);
 	}
 
 #endif /* NANVIX_NOC_PORT_H_ */


### PR DESCRIPTION
# Description #
In this PR, a fair-write system was implemented for the active communicators interface, to avoid indefinite postponement for some threads. It is implemented using a circular FIFO for write requests, granting the channel fair use.