### PR TITLE
[ikc] Ordered and Auxiliary mbuffer Pool

### DIFF
--- a/include/nanvix/kernel/mailbox.h
+++ b/include/nanvix/kernel/mailbox.h
@@ -87,6 +87,7 @@
 	 * @brief Maximum number of auxiliar message buffer resources.
 	 *
 	 * Maximum number of message buffers used to hold temporary data on kernel space.
+	 * WARNING: That constant uses a subset of mbuffers set by @c KMAILBOX_MESSAGE_BUFFERS_MAX
 	 */
 	#define KMAILBOX_AUX_BUFFERS_MAX 16
 

--- a/include/nanvix/kernel/mailbox.h
+++ b/include/nanvix/kernel/mailbox.h
@@ -84,6 +84,13 @@
 	#define KMAILBOX_MESSAGE_BUFFERS_MAX 64
 
 	/**
+	 * @brief Maximum number of auxiliar message buffer resources.
+	 *
+	 * Maximum number of message buffers used to hold temporary data on kernel space.
+	 */
+	#define KMAILBOX_AUX_BUFFERS_MAX 16
+
+	/**
 	 * @brief Mailbox message buffer max size.
 	 *
 	 * Maximum size of mailbox message data buffer.

--- a/include/nanvix/kernel/portal.h
+++ b/include/nanvix/kernel/portal.h
@@ -68,6 +68,11 @@
 	 */
 	#define KPORTAL_MAX (HW_PORTAL_MAX * KPORTAL_PORT_NR)
 
+	/**
+	 * @brief Maximum size of transfer data.
+	 */
+	#define KPORTAL_MAX_SIZE (1 * MB)
+
 #ifdef __NANVIX_MICROKERNEL
 
 	/**
@@ -75,21 +80,22 @@
 	 *
 	 * Size of portal message header.
 	 */
-	#define KPORTAL_MESSAGE_HEADER_SIZE 3*sizeof(int)
+	#define KPORTAL_MESSAGE_HEADER_SIZE (3 * sizeof(int))
 
 	/**
 	 * @brief Maximum number of message buffer resources.
 	 *
 	 * Maximum number of message buffers used to hold temporary data on kernel space.
 	 */
-	#define KPORTAL_MESSAGE_BUFFERS_MAX 32
+	#define KPORTAL_MESSAGE_BUFFERS_MAX (40)
 
 	/**
 	 * @brief Maximum number of auxiliar message buffer resources.
 	 *
 	 * Maximum number of message buffers used to hold temporary data on kernel space.
+	 * WARNING: That constant uses a subset of mbuffers set by @c KPORTAL_MESSAGE_BUFFERS_MAX
 	 */
-	#define KPORTAL_AUX_BUFFERS_MAX 8
+	#define KPORTAL_AUX_BUFFERS_MAX (8)
 
 	/**
 	 * @brief Creates a virtual portal.

--- a/include/nanvix/kernel/portal.h
+++ b/include/nanvix/kernel/portal.h
@@ -85,6 +85,13 @@
 	#define KPORTAL_MESSAGE_BUFFERS_MAX 32
 
 	/**
+	 * @brief Maximum number of auxiliar message buffer resources.
+	 *
+	 * Maximum number of message buffers used to hold temporary data on kernel space.
+	 */
+	#define KPORTAL_AUX_BUFFERS_MAX 8
+
+	/**
 	 * @brief Creates a virtual portal.
 	 *
 	 * @param local Logic ID of the Local Node.

--- a/src/kernel/noc/active.h
+++ b/src/kernel/noc/active.h
@@ -168,52 +168,52 @@
 	struct active
 	{
 		/*
-		* XXX: Don't Touch! This Must Come First!
-		*/
-		struct resource resource;             /**< Generic resource information.   */
+		 * XXX: Don't Touch! This Must Come First!
+		 */
+		struct resource resource;              /**< Generic resource information.               */
 
 		/**
 		 * @name Identification variables.
 		 */
 		/**@{*/
-		int flags;                            /**< Auxiliar flags.                 */
-		int hwfd;                             /**< Underlying file descriptor.     */
-		int local;                            /**< Local node number.              */
-		int remote;                           /**< Target node number.             */
-		int refcount;                         /**< References counter.             */
-		size_t size;                          /**< Data transfer size.             */
+		int flags;                             /**< Auxiliary flags.                            */
+		int hwfd;                              /**< Underlying file descriptor.                 */
+		int local;                             /**< Local node number.                          */
+		int remote;                            /**< Target node number.                         */
+		int refcount;                          /**< References counter.                         */
+		size_t size;                           /**< Data transfer size.                         */
 		/**@}*/
 
 		/**
 		 * @name Auxiliar resources pools.
 		 */
 		/**@{*/
-		struct port_pool portpool;            /**< Port's pool.                    */
-		struct mbuffer_pool * mbufferpool;    /**< Principal mbuffer's pool.       */
-		struct mbuffer_pool * aux_bufferpool; /**< Auxiliar mbuffer's pool.        */
+		struct port_pool portpool;             /**< Pool of port.                               */
+		struct mbuffer_pool * mbufferpool;     /**< Pool with all of mbuffer available.         */
+		struct mbuffer_pool * mbufferpool_aux; /**< Pool with subset of mbuffer in mbufferpool. */
 		/**@}*/
 
 		/**
 		 * @name Control variables.
 		 */
 		/**@{*/
-		struct requests_fifo requests;        /**< Ring buffer of awrite requests. */
-		spinlock_t lock;                      /**< Protection.                     */
+		struct requests_fifo requests;         /**< Ring buffer of awrite requests.             */
+		spinlock_t lock;                       /**< Protection.                                 */
 		/**@}*/
 
 		/**
-		 * @name Auxiliar functions.
+		 * @name Auxiliary functions.
 		 */
 		/**@{*/
-		const hw_create_fn do_create;         /**< Hardware create function.       */
-		const hw_open_fn do_open;             /**< Hardware open function.         */
-		const hw_allow_fn do_allow;           /**< Hardware allow function.        */
-		const hw_aread_fn do_aread;           /**< Hardware aread function.        */
-		const hw_awrite_fn do_awrite;         /**< Hardware awrite function.       */
-		const hw_wait_fn do_wait;             /**< Hardware wait function.         */
-		const hw_copy_fn do_copy;             /**< Mbuffer copy function.          */
-		const hw_config_fn do_header_config;  /**< Header config function.         */
-		const hw_check_fn do_header_check;    /**< Header checker function.        */
+		hw_create_fn do_create;                /**< Hardware create function.                   */
+		hw_open_fn do_open;                    /**< Hardware open function.                     */
+		hw_allow_fn do_allow;                  /**< Hardware allow function.                    */
+		hw_aread_fn do_aread;                  /**< Hardware aread function.                    */
+		hw_awrite_fn do_awrite;                /**< Hardware awrite function.                   */
+		hw_wait_fn do_wait;                    /**< Hardware wait function.                     */
+		hw_copy_fn do_copy;                    /**< Mbuffer copy function.                      */
+		hw_config_fn do_header_config;         /**< Header config function.                     */
+		hw_check_fn do_header_check;           /**< Header checker function.                    */
 		/**@}*/
 	};
 
@@ -223,7 +223,7 @@
 	struct active_pool
 	{
 		struct active * actives; /**< Pool of actives.   */
-		const int nactives;      /**< Number of actives. */
+		int nactives;            /**< Number of actives. */
 	};
 
 	/*============================================================================*

--- a/src/kernel/noc/active.h
+++ b/src/kernel/noc/active.h
@@ -170,49 +170,50 @@
 		/*
 		* XXX: Don't Touch! This Must Come First!
 		*/
-		struct resource resource;            /**< Generic resource information.   */
+		struct resource resource;             /**< Generic resource information.   */
 
 		/**
 		 * @name Identification variables.
 		 */
 		/**@{*/
-		int flags;                           /**< Auxiliar flags.                 */
-		int hwfd;                            /**< Underlying file descriptor.     */
-		int local;                           /**< Local node number.              */
-		int remote;                          /**< Target node number.             */
-		int refcount;                        /**< References counter.             */
-		size_t size;                         /**< Data transfer size.             */
+		int flags;                            /**< Auxiliar flags.                 */
+		int hwfd;                             /**< Underlying file descriptor.     */
+		int local;                            /**< Local node number.              */
+		int remote;                           /**< Target node number.             */
+		int refcount;                         /**< References counter.             */
+		size_t size;                          /**< Data transfer size.             */
 		/**@}*/
 
 		/**
 		 * @name Auxiliar resources pools.
 		 */
 		/**@{*/
-		struct port_pool portpool;           /**< Port's pool.                    */
-		struct mbuffer_pool * mbufferpool;   /**< Mbuffer's pool.                 */
+		struct port_pool portpool;            /**< Port's pool.                    */
+		struct mbuffer_pool * mbufferpool;    /**< Principal mbuffer's pool.       */
+		struct mbuffer_pool * aux_bufferpool; /**< Auxiliar mbuffer's pool.        */
 		/**@}*/
 
 		/**
 		 * @name Control variables.
 		 */
 		/**@{*/
-		struct requests_fifo requests;       /**< Ring buffer of awrite requests. */
-		spinlock_t lock;                     /**< Protection.                     */
+		struct requests_fifo requests;        /**< Ring buffer of awrite requests. */
+		spinlock_t lock;                      /**< Protection.                     */
 		/**@}*/
 
 		/**
 		 * @name Auxiliar functions.
 		 */
 		/**@{*/
-		const hw_create_fn do_create;        /**< Hardware create function.       */
-		const hw_open_fn do_open;            /**< Hardware open function.         */
-		const hw_allow_fn do_allow;          /**< Hardware allow function.        */
-		const hw_aread_fn do_aread;          /**< Hardware aread function.        */
-		const hw_awrite_fn do_awrite;        /**< Hardware awrite function.       */
-		const hw_wait_fn do_wait;            /**< Hardware wait function.         */
-		const hw_copy_fn do_copy;            /**< Mbuffer copy function.          */
-		const hw_config_fn do_header_config; /**< Header config function.         */
-		const hw_check_fn do_header_check;   /**< Header checker function.        */
+		const hw_create_fn do_create;         /**< Hardware create function.       */
+		const hw_open_fn do_open;             /**< Hardware open function.         */
+		const hw_allow_fn do_allow;           /**< Hardware allow function.        */
+		const hw_aread_fn do_aread;           /**< Hardware aread function.        */
+		const hw_awrite_fn do_awrite;         /**< Hardware awrite function.       */
+		const hw_wait_fn do_wait;             /**< Hardware wait function.         */
+		const hw_copy_fn do_copy;             /**< Mbuffer copy function.          */
+		const hw_config_fn do_header_config;  /**< Header config function.         */
+		const hw_check_fn do_header_check;    /**< Header checker function.        */
 		/**@}*/
 	};
 

--- a/src/kernel/noc/mailbox.c
+++ b/src/kernel/noc/mailbox.c
@@ -37,125 +37,48 @@
 #if __TARGET_HAS_MAILBOX
 
 /**
- * @brief Extracts fd and port from mbxid.
+ * @name Auxiliary macros.
  */
 /**@{*/
-#define GET_LADDRESS_FD(mbxid)   (mbxid / MAILBOX_PORT_NR)
-#define GET_LADDRESS_PORT(mbxid) (mbxid % MAILBOX_PORT_NR)
+#define GET_LADDRESS_FD(mbxid)   (mbxid / MAILBOX_PORT_NR) /**< Extracts fd from mbxid.   */
+#define GET_LADDRESS_PORT(mbxid) (mbxid % MAILBOX_PORT_NR) /**< Extracts port from mbxid. */
 /**@}*/
-
-#define MAILBOX_MBUFFER_SRC (-1)
 
 /*============================================================================*
  * Control Structures.                                                        *
  *============================================================================*/
 
-/*----------------------------------------------------------------------------*
- * Mailbox Message Buffer.                                                    *
- *----------------------------------------------------------------------------*/
+/**
+ * @name Pool variables.
+ */
+/**@{*/
+PRIVATE union mailbox_mbuffer mbuffers[KMAILBOX_MESSAGE_BUFFERS_MAX]; /**< Mailbox message buffer.                       */
+PRIVATE uint64_t mbuffers_age;                                        /**< Counter used to set mbuffer age.              */
+PRIVATE spinlock_t mbuffers_lock;                                     /**< Protection of the mbuffer pools.              */
+PRIVATE struct mbuffer_pool mbufferpool;                              /**< Pool with all of mbuffer available.           */
+PRIVATE struct mbuffer_pool mbufferpool_aux;                          /**< Pool with a subset of mbuffer in mbufferpool. */
+/**@}*/
 
 /**
- * @brief Mailbox message buffer.
+ * @name Physical Mailbox variables.
  */
-PRIVATE union mailbox_mbuffer mbxbuffers[KMAILBOX_MESSAGE_BUFFERS_MAX] = {
-	[0 ... (KMAILBOX_MESSAGE_BUFFERS_MAX - 1)] = MBUFFER_INITIALIZER
-};
+/**@{*/
+PRIVATE struct port mbxports[HW_MAILBOX_MAX][MAILBOX_PORT_NR]; /**< Mailbox ports. */
+PRIVATE short fifos[HW_MAILBOX_MAX][MAILBOX_PORT_NR];          /**< Mailbox FIFOs. */
+PRIVATE struct active mailboxes[HW_MAILBOX_MAX];               /**< Mailboxes.    */
+PRIVATE struct active_pool mbxpool;                            /**< Mailbox pool. */
+/**@}*/
 
 /**
- * @brief Principal mbuffer resource pool.
+ * @name Prototype functions.
  */
-PRIVATE struct mbuffer_pool bufferpool = {
-	mbxbuffers,
-	(KMAILBOX_MESSAGE_BUFFERS_MAX - KMAILBOX_AUX_BUFFERS_MAX),
-	sizeof(union mailbox_mbuffer),
-	SPINLOCK_UNLOCKED
-};
-
-/**
- * @brief Auxiliar mbuffer pool.
- */
-PRIVATE struct mbuffer_pool aux_bufferpool = {
-	mbxbuffers + (KMAILBOX_MESSAGE_BUFFERS_MAX - KMAILBOX_AUX_BUFFERS_MAX),
-	KMAILBOX_AUX_BUFFERS_MAX,
-	sizeof(union mailbox_mbuffer),
-	SPINLOCK_UNLOCKED
-};
-
-/*----------------------------------------------------------------------------*
- * Physical Mailboxes.                                                        *
- *----------------------------------------------------------------------------*/
-
+/**@{*/
 int wrapper_mailbox_open(int, int);
 int wrapper_mailbox_allow(struct active *, int);
 int wrapper_mailbox_copy(struct mbuffer *, const struct active_config *, int);
 int mailbox_header_config(struct mbuffer *, const struct active_config *);
 int mailbox_header_check(struct mbuffer *, const struct active_config *);
-
-/**
- * @brief Mailbox ports.
- */
-PRIVATE struct port ports[HW_MAILBOX_MAX][MAILBOX_PORT_NR] = {
-	[0 ... (HW_MAILBOX_MAX - 1)] = {
-		[0 ... (MAILBOX_PORT_NR - 1)] = {
-			.resource    = {0, },
-			.mbufferid   = -1,
-			.mbufferpool = NULL,
-		}
-	}
-};
-
-/**
- * @brief Mailbox FIFOs.
- */
-PRIVATE short fifos[HW_MAILBOX_MAX][MAILBOX_PORT_NR] = {
-	[0 ... (HW_MAILBOX_MAX - 1)] = {
-		[0 ... (MAILBOX_PORT_NR - 1)] = -1,
-	}
-};
-
-/**
- * @brief Mailboxes.
- */
-struct active mailboxes[HW_MAILBOX_MAX] = {
-	[0 ... (HW_MAILBOX_MAX - 1)] {
-		.resource   = {0, },
-		.hwfd       = -1,
-		.local      = -1,
-		.remote     = -1,
-		.refcount   =  0,
-		.size       = HAL_MAILBOX_MSG_SIZE,
-		.portpool       = {
-			.ports      = NULL,
-			.nports     = MAILBOX_PORT_NR,
-			.used_ports = 0,
-		},
-		.requests         = {
-			.head         = 0,
-			.tail         = 0,
-			.max_capacity = MAILBOX_PORT_NR,
-			.nelements    = 0,
-			.fifo         = NULL,
-		},
-		.mbufferpool      = &bufferpool,
-		.aux_bufferpool   = &aux_bufferpool,
-		.do_create        = mailbox_create,
-		.do_open          = wrapper_mailbox_open,
-		.do_allow         = wrapper_mailbox_allow,
-		.do_aread         = mailbox_aread,
-		.do_awrite        = mailbox_awrite,
-		.do_wait          = mailbox_wait,
-		.do_copy          = wrapper_mailbox_copy,
-		.do_header_config = mailbox_header_config,
-		.do_header_check  = mailbox_header_check,
-	},
-};
-
-/**
- * @brief Mailbox pool.
- */
-struct active_pool mbxpool = {
-	mailboxes, HW_MAILBOX_MAX
-};
+/**@}*/
 
 /*============================================================================*
  * do_mailbox_table_init()                                                    *
@@ -166,13 +89,83 @@ struct active_pool mbxpool = {
  */
 void do_mailbox_table_init(void)
 {
+	/* Initializes the mbuffers. */
+	for (int i = 0; i < KMAILBOX_MESSAGE_BUFFERS_MAX; ++i)
+	{
+		mbuffers[i].abstract.resource = RESOURCE_INITIALIZER;
+		mbuffers[i].abstract.age      = ~(0ULL);
+		mbuffers[i].abstract.message  = MBUFFER_MESSAGE_INITIALIZER;
+	}
+
+	/* Initializes shared pool variables. */
+	mbuffers_age = 0ULL;
+	spinlock_init(&mbuffers_lock);
+
+	/* Initializes principal mbuffers pool. */
+	mbufferpool.mbuffers     = mbuffers;
+	mbufferpool.nmbuffers    = KMAILBOX_MESSAGE_BUFFERS_MAX;
+	mbufferpool.mbuffer_size = sizeof(union mailbox_mbuffer);
+	mbufferpool.curr_age     = &mbuffers_age;
+	mbufferpool.lock         = &mbuffers_lock;
+
+	/* Initializes auxiliary mbuffers pool. */
+	mbufferpool_aux.mbuffers     = mbuffers + (KMAILBOX_MESSAGE_BUFFERS_MAX - KMAILBOX_AUX_BUFFERS_MAX);
+	mbufferpool_aux.nmbuffers    = KMAILBOX_AUX_BUFFERS_MAX;
+	mbufferpool_aux.mbuffer_size = sizeof(union mailbox_mbuffer);
+	mbufferpool_aux.curr_age     = &mbuffers_age;
+	mbufferpool_aux.lock         = &mbuffers_lock;
+
+	/* Initializes the mailboxes. */
 	for (int i = 0; i < HW_MAILBOX_MAX; ++i)
 	{
+		/* Initializes main variables. */
 		spinlock_init(&mailboxes[i].lock);
+		mailboxes[i].hwfd           = -1;
+		mailboxes[i].local          = -1;
+		mailboxes[i].remote         = -1;
+		mailboxes[i].refcount       =  0;
+		mailboxes[i].size           = HAL_MAILBOX_MSG_SIZE;
 
-		mailboxes[i].portpool.ports = ports[i];
-		mailboxes[i].requests.fifo  = fifos[i];
+		/* Initializes port pool. */
+		mailboxes[i].portpool.ports      = NULL;
+		mailboxes[i].portpool.nports     = MAILBOX_PORT_NR;
+		mailboxes[i].portpool.used_ports = 0;
+		mailboxes[i].portpool.ports      = mbxports[i];
+
+		/* Initializes request fifo. */
+		mailboxes[i].requests.head         = 0;
+		mailboxes[i].requests.tail         = 0;
+		mailboxes[i].requests.max_capacity = MAILBOX_PORT_NR;
+		mailboxes[i].requests.nelements    = 0;
+		mailboxes[i].requests.fifo         = fifos[i];
+
+		/* Initializes the mailboxes ports and FIFOs. */
+		for (int j = 0; j < MAILBOX_PORT_NR; ++j)
+		{
+			mbxports[i][j].resource    = RESOURCE_INITIALIZER;
+			mbxports[i][j].mbufferid   = -1;
+			mbxports[i][j].mbufferpool = NULL;
+
+			fifos[i][j] = -1;
+		}
+
+		/* Initializes auxiliary functions. */
+		mailboxes[i].mbufferpool      = &mbufferpool;
+		mailboxes[i].mbufferpool_aux  = &mbufferpool_aux;
+		mailboxes[i].do_create        = mailbox_create;
+		mailboxes[i].do_open          = wrapper_mailbox_open;
+		mailboxes[i].do_allow         = wrapper_mailbox_allow;
+		mailboxes[i].do_aread         = mailbox_aread;
+		mailboxes[i].do_awrite        = mailbox_awrite;
+		mailboxes[i].do_wait          = mailbox_wait;
+		mailboxes[i].do_copy          = wrapper_mailbox_copy;
+		mailboxes[i].do_header_config = mailbox_header_config;
+		mailboxes[i].do_header_check  = mailbox_header_check;
 	}
+
+	/* Initializes mailbox pool. */
+	mbxpool.actives  = mailboxes;
+	mbxpool.nactives = HW_MAILBOX_MAX;
 }
 
 /*============================================================================*
@@ -395,6 +388,9 @@ PUBLIC void do_mailbox_init(void)
 
 	local = processor_node_get_num();
 
+	/* Initializes the mailboxes structures. */
+	do_mailbox_table_init();
+
 	/* Create the input mailbox. */
 	KASSERT(_active_create(&mbxpool, local) >= 0);
 
@@ -402,8 +398,6 @@ PUBLIC void do_mailbox_init(void)
 	for (int i = 0; i < PROCESSOR_NOC_NODES_NUM; ++i)
 		KASSERT(_active_open(&mbxpool, local, i) >= 0);
 
-	/* Initializes the active mailboxes locks. */
-	do_mailbox_table_init();
 }
 
 #endif /* __TARGET_HAS_MAILBOX */

--- a/src/kernel/noc/mbuffer.c
+++ b/src/kernel/noc/mbuffer.c
@@ -54,7 +54,7 @@ PUBLIC int mbuffer_alloc(struct mbuffer_pool * pool)
 	size_t size = pool->mbuffer_size;
 
 	KASSERT(pool != NULL);
-	ret = (-EINVAL);
+	ret = (-EBUSY);
 
 	spinlock_lock(&pool->lock);
 
@@ -125,8 +125,8 @@ PUBLIC int mbuffer_release(struct mbuffer_pool * pool, int id, int keep_msg)
 		/* Frees the mbuffer resource. */
 		else
 		{
-			buf->message = MBUFFER_MESSAGE_INITIALIZER;
-			resource_set_unused(&buf->resource);
+			buf->resource = RESOURCE_INITIALIZER;
+			buf->message  = MBUFFER_MESSAGE_INITIALIZER;
 		}
 
 	/* Unlocks the mbuffers table. */

--- a/src/kernel/noc/mbuffer.h
+++ b/src/kernel/noc/mbuffer.h
@@ -66,6 +66,7 @@
 	#define MBUFFER_INITIALIZER {                   \
 		.abstract = {                               \
 			.resource = RESOURCE_INITIALIZER,       \
+			.age      = ~(0ULL),                    \
 			.message  = MBUFFER_MESSAGE_INITIALIZER \
 		}                                           \
 	}
@@ -124,6 +125,7 @@
 		 * XXX: Don't Touch! This Must Come First!
 		 */
 		struct resource resource;       /**< Generic resource information.   */
+		uint64_t age;                   /**< Number that guarantees order.   */
 		struct mbuffer_message message; /**< Structure that holds a message. */
 	};
 
@@ -138,7 +140,8 @@
 			/*
 			* XXX: Don't Touch! This Must Come First!
 			*/
-			struct resource resource;       /**< Generic resource information. */
+			struct resource resource;       /**< Generic resource information.   */
+			uint64_t age;                   /**< Number that guarantees order.   */
 			struct mailbox_message message; /**< Structure that holds a message. */
 		};
 	};
@@ -154,7 +157,8 @@
 			/*
 			* XXX: Don't Touch! This Must Come First!
 			*/
-			struct resource resource;       /**< Generic resource information. */
+			struct resource resource;      /**< Generic resource information.   */
+			uint64_t age;                  /**< Number that guarantees order.   */
 			struct portal_message message; /**< Structure that holds a message. */
 		};
 	};
@@ -167,7 +171,8 @@
 		void * mbuffers;     /**< Pool of mbuffers.        */
 		int nmbuffers;		 /**< Number of mbuffers.      */
 		size_t mbuffer_size; /**< mbuffer size (in bytes). */
-		spinlock_t lock;
+		uint64_t * curr_age; /**< Next mbuffer age.        */
+		spinlock_t * lock;   /**< Protection.              */
 	};
 
 	/*============================================================================*

--- a/src/kernel/noc/port.h
+++ b/src/kernel/noc/port.h
@@ -53,6 +53,7 @@
 		struct resource resource; /**< Generic resource information. */
 		short flags;              /**< Auxiliar flags.               */
 		short mbufferid;          /**< Mbuffer ID.                   */
+		void * mbufferpool;       /**< Mbuffer pool.                 */
 	};
 
 	/**

--- a/src/kernel/noc/port.h
+++ b/src/kernel/noc/port.h
@@ -62,7 +62,7 @@
 	struct port_pool
 	{
 		struct port * ports; /**< Pool of ports.      */
-		const int nports;    /**< Number of ports.    */
+		int nports;          /**< Number of ports.    */
 		int used_ports;      /**< Nr of ports in use. */
 	};
 

--- a/src/kernel/noc/portal.c
+++ b/src/kernel/noc/portal.c
@@ -36,122 +36,47 @@
 #if __TARGET_HAS_PORTAL
 
 /**
- * @brief Extracts fd and port from portalid.
+ * @name Auxiliary macros.
  */
 /**@{*/
-#define GET_LADDRESS_FD(portalid)   (portalid / KPORTAL_PORT_NR)
-#define GET_LADDRESS_PORT(portalid) (portalid % KPORTAL_PORT_NR)
+#define GET_LADDRESS_FD(portalid)   (portalid / KPORTAL_PORT_NR) /**< Extracts fd from portalid.   */
+#define GET_LADDRESS_PORT(portalid) (portalid % KPORTAL_PORT_NR) /**< Extracts port from portalid. */
 /**@}*/
 
 /*============================================================================*
  * Control Structures.                                                        *
  *============================================================================*/
 
-/*----------------------------------------------------------------------------*
- * Portal Message Buffer.                                                     *
- *----------------------------------------------------------------------------*/
+/**
+ * @name Pool variables.
+ */
+/**@{*/
+PRIVATE union portal_mbuffer pbuffers[KPORTAL_MESSAGE_BUFFERS_MAX]; /**< Portal message buffer.                        */
+PRIVATE uint64_t pbuffers_age;                                      /**< Counter used to set mbuffer age.              */
+PRIVATE spinlock_t pbuffers_lock;                                   /**< Protection of the mbuffer pools.              */
+PRIVATE struct mbuffer_pool pbufferpool;                            /**< Pool with all of mbuffer available.           */
+PRIVATE struct mbuffer_pool pbufferpool_aux;                        /**< Pool with a subset of mbuffer in mbufferpool. */
+/**@}*/
 
 /**
- * @brief Portal message buffer.
+ * @name Physical Portal variables.
  */
-PRIVATE union portal_mbuffer portalbuffers[KPORTAL_MESSAGE_BUFFERS_MAX] = {
-	[0 ... (KPORTAL_MESSAGE_BUFFERS_MAX - 1)] = MBUFFER_INITIALIZER
-};
+/**@{*/
+PRIVATE struct port portalports[HW_PORTAL_MAX][KPORTAL_PORT_NR]; /**< Portal ports. */
+PRIVATE short fifos[HW_PORTAL_MAX][KPORTAL_PORT_NR];             /**< Portal FIFOs. */
+PRIVATE struct active portals[HW_PORTAL_MAX];                    /**< Portals.      */
+PRIVATE struct active_pool portalpool;                           /**< Portal pool.  */
+/**@}*/
 
 /**
- * @brief Ubuffer resource pool.
+ * @name Prototype functions.
  */
-PRIVATE struct mbuffer_pool bufferpool = {
-	portalbuffers,
-	(KPORTAL_MESSAGE_BUFFERS_MAX - KPORTAL_AUX_BUFFERS_MAX),
-	sizeof(union portal_mbuffer),
-	SPINLOCK_UNLOCKED
-};
-
-/**
- * @brief Ubuffer resource pool.
- */
-PRIVATE struct mbuffer_pool aux_bufferpool = {
-	portalbuffers + (KPORTAL_MESSAGE_BUFFERS_MAX - KPORTAL_AUX_BUFFERS_MAX),
-	KPORTAL_AUX_BUFFERS_MAX,
-	sizeof(union portal_mbuffer),
-	SPINLOCK_UNLOCKED
-};
-
-/*----------------------------------------------------------------------------*
- * Physical Portals.                                                          *
- *----------------------------------------------------------------------------*/
-
+/**@{*/
 int wrapper_portal_allow(struct active *, int);
 int wrapper_portal_copy(struct mbuffer *, const struct active_config *, int);
 int portal_header_config(struct mbuffer *, const struct active_config *);
 int portal_header_check(struct mbuffer *, const struct active_config *);
-
-/**
- * @brief Portal ports.
- */
-PRIVATE struct port ports[HW_PORTAL_MAX][KPORTAL_PORT_NR] = {
-	[0 ... (HW_PORTAL_MAX - 1)] = {
-		[0 ... (KPORTAL_PORT_NR - 1)] = {
-			.resource    = {0, },
-			.mbufferid   = -1,
-			.mbufferpool = NULL,
-		}
-	}
-};
-
-/**
- * @brief Portal FIFOs.
- */
-PRIVATE short fifos[HW_PORTAL_MAX][KPORTAL_PORT_NR] = {
-	[0 ... (HW_PORTAL_MAX - 1)] = {
-		[0 ... (KPORTAL_PORT_NR - 1)] = -1,
-	}
-};
-
-/**
- * @brief Portales.
- */
-struct active portals[HW_PORTAL_MAX] = {
-	[0 ... (HW_PORTAL_MAX - 1)] {
-		.resource   = {0, },
-		.hwfd       = -1,
-		.local      = -1,
-		.remote     = -1,
-		.refcount   =  0,
-		.size       = (KPORTAL_MESSAGE_HEADER_SIZE + HAL_PORTAL_MAX_SIZE),
-		.portpool       = {
-			.ports      = NULL,
-			.nports     = KPORTAL_PORT_NR,
-			.used_ports = 0,
-		},
-		.requests         = {
-			.head         = 0,
-			.tail         = 0,
-			.max_capacity = KPORTAL_PORT_NR,
-			.nelements    = 0,
-			.fifo         = NULL,
-		},
-		.mbufferpool      = &bufferpool,
-		.aux_bufferpool   = &aux_bufferpool,
-		.do_create        = portal_create,
-		.do_open          = portal_open,
-		.do_allow         = wrapper_portal_allow,
-		.do_aread         = portal_aread,
-		.do_awrite        = portal_awrite,
-		.do_wait          = portal_wait,
-		.do_copy          = wrapper_portal_copy,
-		.do_header_config = portal_header_config,
-		.do_header_check  = portal_header_check,
-	},
-};
-
-/**
- * @brief Portal pool.
- */
-struct active_pool portalpool = {
-	portals, HW_PORTAL_MAX
-};
+/**@}*/
 
 /*============================================================================*
  * do_portal_table_init()                                                     *
@@ -162,13 +87,83 @@ struct active_pool portalpool = {
  */
 void do_portal_table_init(void)
 {
+	/* Initializes the mbuffers. */
+	for (int i = 0; i < KPORTAL_MESSAGE_BUFFERS_MAX; ++i)
+	{
+		pbuffers[i].abstract.resource = RESOURCE_INITIALIZER;
+		pbuffers[i].abstract.age      = ~(0ULL);
+		pbuffers[i].abstract.message  = MBUFFER_MESSAGE_INITIALIZER;
+	}
+
+	/* Initializes shared pool variables. */
+	pbuffers_age = 0ULL;
+	spinlock_init(&pbuffers_lock);
+
+	/* Initializes principal mbuffers pool. */
+	pbufferpool.mbuffers     = pbuffers;
+	pbufferpool.nmbuffers    = KPORTAL_MESSAGE_BUFFERS_MAX;
+	pbufferpool.mbuffer_size = sizeof(union portal_mbuffer);
+	pbufferpool.curr_age     = &pbuffers_age;
+	pbufferpool.lock         = &pbuffers_lock;
+
+	/* Initializes auxiliary mbuffers pool. */
+	pbufferpool_aux.mbuffers     = pbuffers + (KPORTAL_MESSAGE_BUFFERS_MAX - KPORTAL_AUX_BUFFERS_MAX);
+	pbufferpool_aux.nmbuffers    = KPORTAL_AUX_BUFFERS_MAX;
+	pbufferpool_aux.mbuffer_size = sizeof(union portal_mbuffer);
+	pbufferpool_aux.curr_age     = &pbuffers_age;
+	pbufferpool_aux.lock         = &pbuffers_lock;
+
+	/* Initializes the portals. */
 	for (int i = 0; i < HW_PORTAL_MAX; ++i)
 	{
+		/* Initializes main variables. */
 		spinlock_init(&portals[i].lock);
+		portals[i].hwfd           = -1;
+		portals[i].local          = -1;
+		portals[i].remote         = -1;
+		portals[i].refcount       =  0;
+		portals[i].size           = (KPORTAL_MESSAGE_HEADER_SIZE + HAL_PORTAL_MAX_SIZE);
 
-		portals[i].portpool.ports = ports[i];
-		portals[i].requests.fifo  = fifos[i];
+		/* Initializes port pool. */
+		portals[i].portpool.ports      = NULL;
+		portals[i].portpool.nports     = KPORTAL_PORT_NR;
+		portals[i].portpool.used_ports = 0;
+		portals[i].portpool.ports      = portalports[i];
+
+		/* Initializes request fifo. */
+		portals[i].requests.head         = 0;
+		portals[i].requests.tail         = 0;
+		portals[i].requests.max_capacity = KPORTAL_PORT_NR;
+		portals[i].requests.nelements    = 0;
+		portals[i].requests.fifo         = fifos[i];
+
+		/* Initializes the portals ports and FIFOs. */
+		for (int j = 0; j < KPORTAL_PORT_NR; ++j)
+		{
+			portalports[i][j].resource    = RESOURCE_INITIALIZER;
+			portalports[i][j].mbufferid   = -1;
+			portalports[i][j].mbufferpool = NULL;
+
+			fifos[i][j] = -1;
+		}
+
+		/* Initializes auxiliary functions. */
+		portals[i].mbufferpool      = &pbufferpool;
+		portals[i].mbufferpool_aux  = &pbufferpool_aux;
+		portals[i].do_create        = portal_create;
+		portals[i].do_open          = portal_open;
+		portals[i].do_allow         = wrapper_portal_allow;
+		portals[i].do_aread         = portal_aread;
+		portals[i].do_awrite        = portal_awrite;
+		portals[i].do_wait          = portal_wait;
+		portals[i].do_copy          = wrapper_portal_copy;
+		portals[i].do_header_config = portal_header_config;
+		portals[i].do_header_check  = portal_header_check;
 	}
+
+	/* Initializes portal pool. */
+	portalpool.actives  = portals;
+	portalpool.nactives = HW_PORTAL_MAX;
 }
 
 /*============================================================================*
@@ -298,7 +293,7 @@ PUBLIC int do_portal_alloc(int local, int remote, int port, int type)
 /**
  * @brief Releases a physical portal.
  *
- * @param mbxid Active portal ID.
+ * @param portalid Active portal ID.
  *
  * @returns Upon successful completion, zero is returned. Upon
  * failure, a negative error code is returned instead.
@@ -315,7 +310,7 @@ PUBLIC int do_portal_release(int portalid)
 /**
  * @brief Async reads from an active.
  *
- * @param mbxid  Active portal ID.
+ * @param portalid  Active portal ID.
  * @param config Communication's configuration.
  * @param stats  Structure to store statstics.
  *
@@ -334,7 +329,7 @@ PUBLIC ssize_t do_portal_aread(int portalid, const struct active_config * config
 /**
  * @brief Async writes from an active.
  *
- * @param mbxid  Active portal ID.
+ * @param portalid  Active portal ID.
  * @param config Communication's configuration.
  * @param stats  Structure to store statstics.
  *
@@ -353,7 +348,7 @@ PUBLIC ssize_t do_portal_awrite(int portalid, const struct active_config * confi
 /**
  * @brief Waits on a portal to finish an assynchronous operation.
  *
- * @param mbxid  Active portal ID.
+ * @param portalid  Active portal ID.
  * @param config Communication's configuration.
  * @param stats  Structure to store statstics.
  *
@@ -378,15 +373,15 @@ PUBLIC void do_portal_init(void)
 
 	local = processor_node_get_num();
 
+	/* Initializes the portals structures. */
+	do_portal_table_init();
+
 	/* Create the input portal. */
 	KASSERT(_active_create(&portalpool, local) >= 0);
 
 	/* Opens all portal interfaces. */
 	for (int i = 0; i < PROCESSOR_NOC_NODES_NUM; ++i)
 		KASSERT(_active_open(&portalpool, local, i) >= 0);
-
-	/* Initializes the active portals locks. */
-	do_portal_table_init();
 }
 
 #endif /* __TARGET_HAS_PORTAL */


### PR DESCRIPTION
In this PR, we introduce auxiliary pools to use on local communication. The auxiliary pool is a subset of all mbuffers available. Besides that, we add an aging system to mbuffer consume the messages in incoming order.