### PR TITLE
[ikc] Support for Mailbox Communication Only

### DIFF
--- a/include/nanvix/kernel/mailbox.h
+++ b/include/nanvix/kernel/mailbox.h
@@ -88,10 +88,12 @@
 	#define KMAILBOX_MESSAGE_BUFFERS_MAX 64
 
 	/**
-	 * @brief Maximum number of auxiliar message buffer resources.
+	 * @brief Maximum number of auxiliary message buffer resources.
 	 *
 	 * Maximum number of message buffers used to hold temporary data on kernel space.
 	 * WARNING: That constant uses a subset of mbuffers set by @c KMAILBOX_MESSAGE_BUFFERS_MAX
+	 *
+	 * @todo TODO: introduce a check for this.
 	 */
 	#define KMAILBOX_AUX_BUFFERS_MAX 16
 
@@ -205,7 +207,7 @@
 	/**
 	 * @brief Initializes the mailbox facility.
 	 */
-	EXTERN void kmailbox_init(void);
+	EXTERN void vmailbox_init(void);
 
 #endif /* NANVIX_MAILBOX_H_ */
 

--- a/include/nanvix/kernel/mailbox.h
+++ b/include/nanvix/kernel/mailbox.h
@@ -104,6 +104,8 @@
 	 */
 	#define KMAILBOX_MESSAGE_SIZE (HAL_MAILBOX_MSG_SIZE - KMAILBOX_MESSAGE_HEADER_SIZE)
 
+#ifdef __NANVIX_MICROKERNEL
+
 	/**
 	 * @brief Creates a virtual mailbox.
 	 *
@@ -208,6 +210,8 @@
 	 * @brief Initializes the mailbox facility.
 	 */
 	EXTERN void vmailbox_init(void);
+
+#endif /* __NANVIX_MICROKERNEL */
 
 #endif /* NANVIX_MAILBOX_H_ */
 

--- a/include/nanvix/kernel/mailbox.h
+++ b/include/nanvix/kernel/mailbox.h
@@ -49,7 +49,12 @@
 	 *
 	 * Maximum number of virtual mailboxes that can be vinculated to each HW mailbox.
 	 */
-	#define MAILBOX_PORT_NR 16
+	#define MAILBOX_PORT_NR 32
+
+	/**
+	 * @brief Number of ports per Kernel mailbox.
+	 */
+	#define KMAILBOX_PORT_NR 16
 
 	/**
 	 * @brief Maximum number of HW mailboxes.

--- a/include/nanvix/kernel/portal.h
+++ b/include/nanvix/kernel/portal.h
@@ -217,7 +217,7 @@
 	/**
 	 * @brief Initializes the portal facility.
 	 */
-	EXTERN void kportal_init(void);
+	EXTERN void vportal_init(void);
 
 #endif /* __NANVIX_MICROKERNEL */
 

--- a/include/nanvix/kernel/sync.h
+++ b/include/nanvix/kernel/sync.h
@@ -115,7 +115,7 @@
 	/**
 	 * @brief Initializes the synchronization facility.
 	 */
-	EXTERN void ksync_init(void);
+	EXTERN void vsync_init(void);
 
 #endif /* NANVIX_SYNC_H_ */
 

--- a/include/nanvix/kernel/sync.h
+++ b/include/nanvix/kernel/sync.h
@@ -42,6 +42,8 @@
 	 */
 	#define KSYNC_MAX 1024
 
+#ifdef __NANVIX_MICROKERNEL
+
 	/**
 	 * @brief Creates a virtual synchronization point.
 	 *
@@ -116,6 +118,8 @@
 	 * @brief Initializes the synchronization facility.
 	 */
 	EXTERN void vsync_init(void);
+
+#endif /* __NANVIX_MICROKERNEL */
 
 #endif /* NANVIX_SYNC_H_ */
 

--- a/src/kernel/noc/noc.c
+++ b/src/kernel/noc/noc.c
@@ -29,8 +29,8 @@
  * The noc_init() function initializes the Network-on-Chip (NoC)
  * system. It initializes and setups the IKC structures: (i) Sync.
  *
- * @see ksync_init().
- * @see kmailbox_init().
+ * @see vsync_init().
+ * @see vmailbox_init().
  *
  * @author Joao Fellipe Uller
  */
@@ -39,14 +39,14 @@ PUBLIC void noc_init(void)
 	kprintf("[kernel][noc] initializing the noc system");
 
 	#if __TARGET_HAS_SYNC
-		ksync_init();
+		vsync_init();
 	#endif
 
 	#if __TARGET_HAS_MAILBOX
-		kmailbox_init();
+		vmailbox_init();
 	#endif
 
 	#if __TARGET_HAS_PORTAL
-		kportal_init();
+		vportal_init();
 	#endif
 }

--- a/src/kernel/noc/sync.c
+++ b/src/kernel/noc/sync.c
@@ -453,13 +453,13 @@ PUBLIC int do_vsync_signal(int syncid)
 }
 
 /*============================================================================*
- * ksync_init()                                                               *
+ * vsync_init()                                                               *
  *============================================================================*/
 
 /**
  * @todo TODO: Provide a detailed description for this function.
  */
-PUBLIC void ksync_init(void)
+PUBLIC void vsync_init(void)
 {
 	kprintf("[kernel][noc] initializing the ksync facility");
 }

--- a/src/kernel/noc/vmailbox.c
+++ b/src/kernel/noc/vmailbox.c
@@ -57,13 +57,13 @@ PRIVATE struct communicator_pool vmbxpool;                                   /**
 /**@}*/
 
 /*============================================================================*
- * do_kmailbox_init()                                                        *
+ * do_vmailbox_init()                                                        *
  *============================================================================*/
 
 /**
  * @brief Initializes the mbuffers table lock.
  */
-PRIVATE void do_kmailbox_init(void)
+PRIVATE void do_vmailbox_init(void)
 {
 	for (int i = 0; i < KMAILBOX_MAX; ++i)
 	{
@@ -335,13 +335,13 @@ int do_vmailbox_get_port(int mbxid)
 }
 
 /*============================================================================*
- * kmailbox_init()                                                            *
+ * vmailbox_init()                                                            *
  *============================================================================*/
 
 /**
  * @brief Initializes the mailbox service.
  */
-PUBLIC void kmailbox_init(void)
+PUBLIC void vmailbox_init(void)
 {
 	kprintf("[kernel][noc] initializing the kmailbox facility");
 
@@ -349,7 +349,7 @@ PUBLIC void kmailbox_init(void)
 	do_mailbox_init();
 
 	/* Initializes the virtual mailboxes structures. */
-	do_kmailbox_init();
+	do_vmailbox_init();
 }
 
 #endif /* __TARGET_HAS_MAILBOX */

--- a/src/kernel/noc/vportal.c
+++ b/src/kernel/noc/vportal.c
@@ -56,13 +56,13 @@ PRIVATE struct communicator_pool vportalpool;                             /**< V
 /**@}*/
 
 /*============================================================================*
- * do_kportal_init()                                                          *
+ * do_vportal_init()                                                          *
  *============================================================================*/
 
 /**
  * @brief Initializes the mbuffers table lock.
  */
-PRIVATE void do_kportal_init(void)
+PRIVATE void do_vportal_init(void)
 {
 	for (int i = 0; i < KPORTAL_MAX; ++i)
 	{
@@ -391,13 +391,13 @@ int do_vportal_get_port(int portalid)
 }
 
 /*============================================================================*
- * kportal_init()                                                             *
+ * vportal_init()                                                             *
  *============================================================================*/
 
 /**
  * @todo TODO: Provide a detailed description for this function.
  */
-PUBLIC void kportal_init(void)
+PUBLIC void vportal_init(void)
 {
 	kprintf("[kernel][noc] initializing the kportal facility");
 
@@ -405,7 +405,7 @@ PUBLIC void kportal_init(void)
 	do_portal_init();
 
 	/* Initializes the virtual portals structures. */
-	do_kportal_init();
+	do_vportal_init();
 }
 
 #endif /* __TARGET_HAS_PORTAL */

--- a/src/kernel/sys/mailbox.c
+++ b/src/kernel/sys/mailbox.c
@@ -115,7 +115,7 @@ PUBLIC int kernel_mailbox_awrite(int mbxid, const void *buffer, size_t size)
 		return (-EINVAL);
 
 	/* Invalid write size. */
-	if (size != KMAILBOX_MESSAGE_SIZE)
+	if ((size == 0) || (size > KMAILBOX_MESSAGE_SIZE))
 		return (-EINVAL);
 
 	/* Invalid buffer. */
@@ -143,7 +143,7 @@ PUBLIC int kernel_mailbox_aread(int mbxid, void *buffer, size_t size)
 		return (-EINVAL);
 
 	/* Invalid read size. */
-	if (size != KMAILBOX_MESSAGE_SIZE)
+	if ((size == 0) || (size > KMAILBOX_MESSAGE_SIZE))
 		return (-EINVAL);
 
 	/* Invalid buffer. */


### PR DESCRIPTION
# Description

In this PR, I increase the number of virtual mailbox ports to share between the mailbox, portal, and sync when using only the mailbox ports for communication. If it is disabled, all ports are available for the mailboxes.

I also allowed a variable mailbox size within the maximum size previously stipulated. In practice, only the initial checks change, the rest continue with the same behavior.