### PR TITLE
[ikc] Increase Number of Ports for Abstractions

### DIFF
--- a/include/nanvix/kernel/mailbox.h
+++ b/include/nanvix/kernel/mailbox.h
@@ -59,7 +59,7 @@
 #if __NANVIX_IKC_USES_ONLY_MAILBOX
 	#define MAILBOX_PORT_NR (64)
 #else
-	#define MAILBOX_PORT_NR (16)
+	#define MAILBOX_PORT_NR (24)
 #endif
 
 	/**
@@ -68,7 +68,7 @@
 #if __NANVIX_IKC_USES_ONLY_MAILBOX
 	#define KMAILBOX_PORT_NR (32)
 #else
-	#define KMAILBOX_PORT_NR (16)
+	#define KMAILBOX_PORT_NR (24)
 #endif
 
 	/**

--- a/include/nanvix/kernel/portal.h
+++ b/include/nanvix/kernel/portal.h
@@ -58,7 +58,7 @@
 	/**
 	 * @brief Number of ports per portal.
 	 */
-	#define KPORTAL_PORT_NR 16
+	#define KPORTAL_PORT_NR 24
 
 	/**
 	 * @brief Maximum number of active portals.


### PR DESCRIPTION
# Description #
This PR is a small patch to increase the IKC Structures Ports to 24 instead 16, making available a new special range of ports to be used for general purpose, without risking interference with system used ports.

# Related Issues #
- Closes #270 - [[ikc] Increase IKC Structures Port Range](https://github.com/nanvix/microkernel/issues/270)

# Related BUGs #
- #271 - [[ikc] Widening IKC Ports Range breaks execution in MPPA-256](https://github.com/nanvix/microkernel/issues/271)