### PR TITLE
[ikc] Specifying Mailbox Source

### DIFF
--- a/include/nanvix/kernel/mailbox.h
+++ b/include/nanvix/kernel/mailbox.h
@@ -40,14 +40,15 @@
 	 * @name Mailbox I/O Control types.
 	 */
 	/**@{*/
-	#define KMAILBOX_IOCTL_GET_VOLUME   (1) /**< Gets communication volume.  */
-	#define KMAILBOX_IOCTL_GET_LATENCY  (2) /**< Gets communication latency. */
-	#define KMAILBOX_IOCTL_GET_NCREATES (3) /**< Gets number of creates.     */
-	#define KMAILBOX_IOCTL_GET_NUNLINKS (4) /**< Gets number of unlinks.     */
-	#define KMAILBOX_IOCTL_GET_NOPENS   (5) /**< Gets number of opens.       */
-	#define KMAILBOX_IOCTL_GET_NCLOSES  (6) /**< Gets number of closes.      */
-	#define KMAILBOX_IOCTL_GET_NREADS   (7) /**< Gets number of reads.       */
-	#define KMAILBOX_IOCTL_GET_NWRITES  (8) /**< Gets number of writes.      */
+	#define KMAILBOX_IOCTL_GET_VOLUME   (1) /**< Gets communication volume.            */
+	#define KMAILBOX_IOCTL_GET_LATENCY  (2) /**< Gets communication latency.           */
+	#define KMAILBOX_IOCTL_GET_NCREATES (3) /**< Gets number of creates.               */
+	#define KMAILBOX_IOCTL_GET_NUNLINKS (4) /**< Gets number of unlinks.               */
+	#define KMAILBOX_IOCTL_GET_NOPENS   (5) /**< Gets number of opens.                 */
+	#define KMAILBOX_IOCTL_GET_NCLOSES  (6) /**< Gets number of closes.                */
+	#define KMAILBOX_IOCTL_GET_NREADS   (7) /**< Gets number of reads.                 */
+	#define KMAILBOX_IOCTL_GET_NWRITES  (8) /**< Gets number of writes.                */
+	#define KMAILBOX_IOCTL_SET_REMOTE   (9) /**< Sets the remote_addr until next read. */
 	/**@}*/
 
 	/**
@@ -69,6 +70,12 @@
 #else
 	#define KMAILBOX_PORT_NR (16)
 #endif
+
+	/**
+	 * @brief Auxiliary definitions for src header check.
+	 */
+	#define MAILBOX_ANY_SOURCE PROCESSOR_NOC_NODES_NUM
+	#define MAILBOX_ANY_PORT   MAILBOX_PORT_NR
 
 	/**
 	 * @brief Maximum number of HW mailboxes.

--- a/include/nanvix/kernel/portal.h
+++ b/include/nanvix/kernel/portal.h
@@ -90,6 +90,12 @@
 	 */
 	#define KPORTAL_MAX_SIZE (1 * MB)
 
+	/**
+	 * @brief Auxiliary definitions for src header check.
+	 */
+	#define PORTAL_ANY_SOURCE PROCESSOR_NOC_NODES_NUM
+	#define PORTAL_ANY_PORT   KPORTAL_PORT_NR
+
 #ifdef __NANVIX_MICROKERNEL
 
 	/**

--- a/src/kernel/noc/active.h
+++ b/src/kernel/noc/active.h
@@ -150,6 +150,7 @@
 	typedef int (* active_release_fn)(int);
 	typedef ssize_t (* active_comm_fn)(int, const struct active_config *, struct pstats *);
 	typedef int (* active_wait_fn)(int, const struct active_config *, struct pstats *);
+	typedef int (* active_laddress_calc_fn)(int, int);
 	/**@}*/
 
 	/*============================================================================*
@@ -161,16 +162,16 @@
 	 */
 	struct active_functions
 	{
-		hw_create_fn do_create;        /**< Hardware create function.                   */
-		hw_open_fn do_open;            /**< Hardware open function.                     */
-		hw_allow_fn do_allow;          /**< Hardware allow function.                    */
-		hw_aread_fn do_aread;          /**< Hardware aread function.                    */
-		hw_awrite_fn do_awrite;        /**< Hardware awrite function.                   */
-		hw_wait_fn do_wait;            /**< Hardware wait function.                     */
-		hw_config_fn do_header_config; /**< Header config function.                     */
-		hw_check_fn do_header_check;   /**< Header checker function.                    */
-		hw_getter_fn get_actid;        /**< Gets active id from a composed ID.          */
-		hw_getter_fn get_portid;       /**< Gets port id from a composed ID.            */
+		hw_create_fn do_create;        /**< Hardware create function.          */
+		hw_open_fn do_open;            /**< Hardware open function.            */
+		hw_allow_fn do_allow;          /**< Hardware allow function.           */
+		hw_aread_fn do_aread;          /**< Hardware aread function.           */
+		hw_awrite_fn do_awrite;        /**< Hardware awrite function.          */
+		hw_wait_fn do_wait;            /**< Hardware wait function.            */
+		hw_config_fn do_header_config; /**< Header config function.            */
+		hw_check_fn do_header_check;   /**< Header checker function.           */
+		hw_getter_fn get_actid;        /**< Gets active id from a composed ID. */
+		hw_getter_fn get_portid;       /**< Gets port id from a composed ID.   */
 	};
 
 	/**

--- a/src/kernel/noc/active.h
+++ b/src/kernel/noc/active.h
@@ -53,7 +53,7 @@
 	/**
 	 * @brief Composes the logic address based on logid id, logic portid and number of ports.
 	 */
-	#define ACTIVE_LADDRESS_COMPOSE(_fd, _port, _nports) (_fd * _nports + _port)
+	#define ACTIVE_LADDRESS_COMPOSE(_fd, _port, _nports) (_fd * (_nports + 1) + _port)
 
 	/**
 	 * @name Communication types.
@@ -99,7 +99,7 @@
 	struct active_config
 	{
 		int fd;              /**< Active id.          */
-		int local_addr;      /**< Remote address.     */
+		int local_addr;      /**< Local address.      */
 		int remote_addr;     /**< Remote address.     */
 		const void * buffer; /**< User level buffer.  */
 		size_t size;         /**< Data transfer size. */

--- a/src/kernel/noc/communicator.c
+++ b/src/kernel/noc/communicator.c
@@ -299,7 +299,7 @@ PUBLIC int communicator_wait(struct communicator * comm)
 				comm->config.remote_addr = -1;
 
 			spinlock_lock(&comm->counters->lock);
-				if (!resource_is_readable(&comm->resource))
+				if (resource_is_readable(&comm->resource))
 					comm->counters->nreads++;
 				else
 					comm->counters->nwrites++;

--- a/src/kernel/noc/communicator.h
+++ b/src/kernel/noc/communicator.h
@@ -54,14 +54,15 @@
 	 * @name I/O Control types.
 	 */
 	/**@{*/
-	#define COMM_IOCTL_GET_VOLUME   (1) /**< Gets communication volume.  */
-	#define COMM_IOCTL_GET_LATENCY  (2) /**< Gets communication latency. */
-	#define COMM_IOCTL_GET_NCREATES (3) /**< Gets number of creates.     */
-	#define COMM_IOCTL_GET_NUNLINKS (4) /**< Gets number of unlinks.     */
-	#define COMM_IOCTL_GET_NOPENS   (5) /**< Gets number of opens.       */
-	#define COMM_IOCTL_GET_NCLOSES  (6) /**< Gets number of closes.      */
-	#define COMM_IOCTL_GET_NREADS   (7) /**< Gets number of reads.       */
-	#define COMM_IOCTL_GET_NWRITES  (8) /**< Gets number of writes.      */
+	#define COMM_IOCTL_GET_VOLUME   (1) /**< Gets communication volume.            */
+	#define COMM_IOCTL_GET_LATENCY  (2) /**< Gets communication latency.           */
+	#define COMM_IOCTL_GET_NCREATES (3) /**< Gets number of creates.               */
+	#define COMM_IOCTL_GET_NUNLINKS (4) /**< Gets number of unlinks.               */
+	#define COMM_IOCTL_GET_NOPENS   (5) /**< Gets number of opens.                 */
+	#define COMM_IOCTL_GET_NCLOSES  (6) /**< Gets number of closes.                */
+	#define COMM_IOCTL_GET_NREADS   (7) /**< Gets number of reads.                 */
+	#define COMM_IOCTL_GET_NWRITES  (8) /**< Gets number of writes.                */
+	#define COMM_IOCTL_SET_REMOTE   (9) /**< Sets the remote_addr until next read. */
 	/**@}*/
 
 	/**
@@ -104,9 +105,10 @@
 	 */
 	struct communicator_functions
 	{
-		active_release_fn do_release; /**< Active release function.      */
-		active_comm_fn do_comm;       /**< Active comm function.         */
-		active_wait_fn do_wait;       /**< Active wait function.         */
+		active_release_fn do_release;          /**< Active release function. */
+		active_comm_fn do_comm;                /**< Active comm function.    */
+		active_wait_fn do_wait;                /**< Active wait function.    */
+		active_laddress_calc_fn laddress_calc; /**< Active laddress calc.    */
 	};
 
 	/**

--- a/src/kernel/noc/mailbox.h
+++ b/src/kernel/noc/mailbox.h
@@ -45,6 +45,7 @@
 	EXTERN ssize_t do_mailbox_aread(int, const struct active_config *, struct pstats *);
 	EXTERN ssize_t do_mailbox_awrite(int, const struct active_config *, struct pstats *);
 	EXTERN int do_mailbox_wait(int, const struct active_config *, struct pstats *);
+	EXTERN int mailbox_laddress_calc(int, int);
 
 	EXTERN void do_mailbox_init(void);
 

--- a/src/kernel/noc/mbuffer.c
+++ b/src/kernel/noc/mbuffer.c
@@ -197,7 +197,7 @@ PUBLIC int mbuffer_search(struct mbuffer_pool * pool, int dest, int src)
 				continue;
 
 			/* Checks the message source if it was the expected. */
-			if ((src != -1) && (!pool->source_check(buf, src)))
+			if (!pool->source_check(buf, src))
 				continue;
 
 			/* Is the buffer the older? */

--- a/src/kernel/noc/mbuffer.c
+++ b/src/kernel/noc/mbuffer.c
@@ -196,8 +196,8 @@ PUBLIC int mbuffer_search(struct mbuffer_pool * pool, int dest, int src)
 			if (buf->message.header.dest != dest)
 				continue;
 
-			/* Is the message sender the expected? */
-			if (src != -1 && buf->message.header.src != src)
+			/* Checks the message source if it was the expected. */
+			if ((src != -1) && (!pool->source_check(buf, src)))
 				continue;
 
 			/* Is the buffer the older? */

--- a/src/kernel/noc/mbuffer.h
+++ b/src/kernel/noc/mbuffer.h
@@ -203,6 +203,11 @@
 	};
 
 	/**
+	 * @brief Prototype function to check source of a message.
+	 */
+	typedef int (* source_check_fn)(struct mbuffer *, int);
+
+	/**
 	 * @brief Resource pool.
 	 */
 	struct mbuffer_pool
@@ -212,6 +217,8 @@
 		size_t mbuffer_size; /**< mbuffer size (in bytes). */
 		uint64_t * curr_age; /**< Next mbuffer age.        */
 		spinlock_t * lock;   /**< Protection.              */
+
+		source_check_fn source_check; /**< Source header check. */
 	};
 
 	/*============================================================================*

--- a/src/kernel/noc/portal.h
+++ b/src/kernel/noc/portal.h
@@ -46,6 +46,7 @@
 	EXTERN ssize_t do_portal_aread(int, const struct active_config *, struct pstats *);
 	EXTERN ssize_t do_portal_awrite(int, const struct active_config *, struct pstats *);
 	EXTERN int do_portal_wait(int, const struct active_config *, struct pstats *);
+	EXTERN int portal_laddress_calc(int, int);
 
 	EXTERN void do_portal_init(void);
 

--- a/src/kernel/noc/vmailbox.c
+++ b/src/kernel/noc/vmailbox.c
@@ -40,7 +40,7 @@
  * @brief Extracts fd and port from mbxid.
  */
 /**@{*/
-#define VMAILBOX_GET_LADDRESS_PORT(mbxid) (mbxid % MAILBOX_PORT_NR)
+#define VMAILBOX_GET_LADDRESS_PORT(mbxid) (mbxid % (MAILBOX_PORT_NR + 1))
 /**@}*/
 
 /*============================================================================*

--- a/src/kernel/noc/vmailbox.c
+++ b/src/kernel/noc/vmailbox.c
@@ -74,9 +74,10 @@ PRIVATE void do_vmailbox_init(void)
 	vmailbox_counters.nreads   = 0ULL;
 	vmailbox_counters.nwrites  = 0ULL;
 
-	vmailbox_functions.do_release = do_mailbox_release;
-	vmailbox_functions.do_comm    = do_mailbox_aread;
-	vmailbox_functions.do_wait    = do_mailbox_wait;
+	vmailbox_functions.do_release    = do_mailbox_release;
+	vmailbox_functions.do_comm       = do_mailbox_aread;
+	vmailbox_functions.do_wait       = do_mailbox_wait;
+	vmailbox_functions.laddress_calc = mailbox_laddress_calc;
 
 	for (int i = 0; i < KMAILBOX_MAX; ++i)
 	{
@@ -85,7 +86,6 @@ PRIVATE void do_vmailbox_init(void)
 		vmailboxes[i].config     = ACTIVE_CONFIG_INITIALIZER;
 		vmailboxes[i].stats      = PSTATS_INITIALIZER;
 		vmailboxes[i].fn         = &vmailbox_functions;
-
 		vmailboxes[i].counters   = &vmailbox_counters;
 	}
 
@@ -299,10 +299,6 @@ PUBLIC int do_vmailbox_awrite(int mbxid, const void * buffer, size_t size)
  */
 PUBLIC int do_vmailbox_wait(int mbxid)
 {
-	/* This is only a test. Remove it.*/
-	if (resource_is_readable(&vmailboxes[mbxid].resource))
-		KASSERT(vmailboxes[mbxid].config.remote_addr == -1);
-
 	return (communicator_wait(&vmailboxes[mbxid]));
 }
 

--- a/src/kernel/noc/vportal.c
+++ b/src/kernel/noc/vportal.c
@@ -73,9 +73,10 @@ PRIVATE void do_vportal_init(void)
 	vportal_counters.nreads   = 0ULL;
 	vportal_counters.nwrites  = 0ULL;
 
-	vportal_functions.do_release = do_portal_release;
-	vportal_functions.do_comm    = do_portal_aread;
-	vportal_functions.do_wait    = do_portal_wait;
+	vportal_functions.do_release    = do_portal_release;
+	vportal_functions.do_comm       = do_portal_aread;
+	vportal_functions.do_wait       = do_portal_wait;
+	vportal_functions.laddress_calc = portal_laddress_calc;
 
 	for (int i = 0; i < KPORTAL_MAX; ++i)
 	{

--- a/src/kernel/noc/vportal.c
+++ b/src/kernel/noc/vportal.c
@@ -39,7 +39,7 @@
  * @brief Extracts fd and port from portalid.
  */
 /**@{*/
-#define VPORTAL_GET_LADDRESS_PORT(portalid) (portalid % KPORTAL_PORT_NR)
+#define VPORTAL_GET_LADDRESS_PORT(portalid) (portalid % (KPORTAL_PORT_NR + 1))
 /**@}*/
 
 /*============================================================================*


### PR DESCRIPTION
# Description #
In this PR we provide a way for the user to specify from which source it wants to receive a message during a `mailbox_read()` operation. This can be achieved by calling `kmailbox_ioctl()` using the `KMAILBOX_IOCTL_SET_REMOTE` operation. It sets the `remote_addr` of the specified mailbox  to the specified source and will configure it to read a message sent by that. This change is valid for a single read (similar to `portal_allow()`), and must be redone for successive reads from the same source, and can also specify to look only for specific ports or specific nodes independently, passing any of the constants `MAILBOX_ANY_SOURCE` or `MAILBOX_ANY_PORT` to the IOCTL operation. 

**Note:** Using this IOCTL operation and passing MAILBOX_ANY_SOURCE and MAILBOX_ANY_PORT as parameters in the same call gives the same result as if this operation wasn't made. The mailbox will read the first pendent message to this destination in the same way it would be done in the default behavior.

# Related Issues #
- Closes #272 - [[ikc] Mailbox Source Specification](https://github.com/nanvix/microkernel/issues/272)