### PR TITLE
[ikc] Enhancement: Align IKC buffers on 8-byte addresses

### DIFF
--- a/src/kernel/noc/mailbox.c
+++ b/src/kernel/noc/mailbox.c
@@ -449,6 +449,11 @@ PUBLIC void do_mailbox_init(void)
 
 	local = processor_node_get_num();
 
+	KASSERT((((unsigned long) &mbuffers[0].message) & 0x7) == 0);
+	KASSERT((((unsigned long) &mbuffers[1].message) & 0x7) == 0);
+	KASSERT((sizeof(mbuffers[0].message) % 8) == 0);
+	KASSERT((sizeof(mbuffers[1].message) % 8) == 0);
+
 	/* Initializes the mailboxes structures. */
 	do_mailbox_table_init();
 

--- a/src/kernel/noc/mbuffer.h
+++ b/src/kernel/noc/mbuffer.h
@@ -53,13 +53,13 @@
 	/**
 	 * @brief Size of the mbuffer message header.
 	 */
-	#define MBUFFER_HEADER_SIZE (3 * 4) /**< sizeof(struct mbuffer_header) */
+	#define MBUFFER_HEADER_SIZE (4 * 4) /**< sizeof(struct mbuffer_header) */
 
 	/**
 	 * @brief Mbuffer message initializer.
 	 */
 	#define MBUFFER_MESSAGE_INITIALIZER (struct mbuffer_message){ \
-		.header = {-1, -1, 0},                                    \
+		.header = {-1, -1, 0, 0},                                 \
 		.data   = '\0',                                           \
 	}
 
@@ -86,9 +86,10 @@
 	 */
 	struct mbuffer_header
 	{
-		int dest; /* Data sender.       */
-		int src;  /* Data destination.  */
-		int size; /* Message data size. */
+		int dest;   /* Data sender.         */
+		int src;    /* Data destination.    */
+		int size;   /* Message data size.   */
+		int unused; /* Padding to 16 bytes. */
 	};
 
 	/**
@@ -132,7 +133,7 @@
 #if (MBUFFER_HEADER_SIZE < KMAILBOX_MESSAGE_HEADER_SIZE)
 		char unused[KMAILBOX_MESSAGE_HEADER_SIZE - MBUFFER_HEADER_SIZE]; /* Unused. */
 #endif
-	};
+	} ALIGN(sizeof(dword_t));
 
 	/**
 	 * @brief Portal message.
@@ -144,7 +145,7 @@
 #if (MBUFFER_HEADER_SIZE < KPORTAL_MESSAGE_HEADER_SIZE)
 		char unused[KPORTAL_MESSAGE_HEADER_SIZE - MBUFFER_HEADER_SIZE]; /* Unused. */
 #endif
-	};
+	} ALIGN(sizeof(dword_t));
 
 	/**
 	 * @brief Abstract mbuffer.
@@ -180,7 +181,7 @@
 			int portid;                     /**< Sender port ID of local sender.   */
 			struct mailbox_message message; /**< Structure that holds a message.   */
 		};
-	};
+	} ALIGN(sizeof(dword_t));
 
 	/**
 	 * @brief Portal mbuffer.
@@ -200,7 +201,7 @@
 			int portid;                    /**< Sender port ID of local sender.    */
 			struct portal_message message; /**< Structure that holds a message.    */
 		};
-	};
+	} ALIGN(sizeof(dword_t));
 
 	/**
 	 * @brief Prototype function to check source of a message.

--- a/src/kernel/noc/portal.c
+++ b/src/kernel/noc/portal.c
@@ -433,6 +433,11 @@ PUBLIC void do_portal_init(void)
 
 	local = processor_node_get_num();
 
+	KASSERT((((uintptr_t) &pbuffers[0].message) & 0x7) == 0);
+	KASSERT((((uintptr_t) &pbuffers[1].message) & 0x7) == 0);
+	KASSERT((sizeof(pbuffers[0].message) % 8) == 0);
+	KASSERT((sizeof(pbuffers[1].message) % 8) == 0);
+
 	/* Initializes the portals structures. */
 	do_portal_table_init();
 
@@ -445,3 +450,4 @@ PUBLIC void do_portal_init(void)
 }
 
 #endif /* __TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX */
+


### PR DESCRIPTION
In this PR, we force IKC buffers to be aligned on 8-byte addresses. This change benefits the architectures that work better with aligned memories.