### PR TITLE
[tm] Thread Scheduler

### DIFF
--- a/include/nanvix/kernel/syscall.h
+++ b/include/nanvix/kernel/syscall.h
@@ -48,67 +48,67 @@
 	 * @note This should be set to the highest system call number.
 	 */
 	#define NR_SYSCALLS NR_last_kcall
-
 	/**
 	 * @name System Call Numbers
 	 */
 	/**@{*/
-	#define NR__exit            1 /**< kernel_exit()            */
-	#define NR_write            2 /**< kernel_write()           */
-	#define NR_thread_get_id    3 /**< kernel_thread_get_id()   */
-	#define NR_thread_create    4 /**< kernel_thread_create()   */
-	#define NR_thread_exit      5 /**< kernel_thread_exit()     */
-	#define NR_thread_join      6 /**< kernel_thread_join()     */
-	#define NR_sleep            7 /**< kernel_sleep()           */
-	#define NR_wakeup           8 /**< kernel_wakeup()          */
-	#define NR_shutdown         9 /**< kernel_shutdown()        */
-	#define NR_sigctl          10 /**< kernel_sigctl()          */
-	#define NR_alarm           11 /**< kernel_alarm()           */
-	#define NR_sigsend         12 /**< kernel_sigsend()         */
-	#define NR_sigwait         13 /**< kernel_sigwait()         */
-	#define NR_sigreturn       14 /**< kernel_sigreturn()       */
-	#define NR_node_get_num    15 /**< kernel_node_get_num()    */
-	#define NR_sync_create     16 /**< kernel_sync_create()     */
-	#define NR_sync_open       17 /**< kernel_sync_open()       */
-	#define NR_sync_unlink     18 /**< kernel_sync_unlink()     */
-	#define NR_sync_close      19 /**< kernel_sync_close()      */
-	#define NR_sync_wait       20 /**< kernel_sync_wait()       */
-	#define NR_sync_signal     21 /**< kernel_sync_signal()     */
-	#define NR_sync_ioctl      22 /**< kernel_sync_ioctl()      */
-	#define NR_mailbox_create  23 /**< kernel_mailbox_create()  */
-	#define NR_mailbox_open    24 /**< kernel_mailbox_open()    */
-	#define NR_mailbox_unlink  25 /**< kernel_mailbox_unlink()  */
-	#define NR_mailbox_close   26 /**< kernel_mailbox_close()   */
-	#define NR_mailbox_awrite  27 /**< kernel_mailbox_awrite()  */
-	#define NR_mailbox_aread   28 /**< kernel_mailbox_aread()   */
-	#define NR_mailbox_wait    29 /**< kernel_mailbox_wait()    */
-	#define NR_mailbox_ioctl   30 /**< kernel_mailbox_ioctl()   */
-	#define NR_portal_create   31 /**< kernel_portal_create()   */
-	#define NR_portal_allow    32 /**< kernel_portal_allow()    */
-	#define NR_portal_open     33 /**< kernel_portal_open()     */
-	#define NR_portal_unlink   34 /**< kernel_portal_unlink()   */
-	#define NR_portal_close    35 /**< kernel_portal_close()    */
-	#define NR_portal_awrite   36 /**< kernel_portal_awrite()   */
-	#define NR_portal_aread    37 /**< kernel_portal_aread()    */
-	#define NR_portal_wait     38 /**< kernel_portal_wait()     */
-	#define NR_portal_ioctl    39 /**< kernel_portal_ioctl()    */
-	#define NR_clock           40 /**< kernel_clock()           */
-	#define NR_stats           42 /**< kernel_stats()           */
-	#define NR_frame_alloc     43 /**< kernel_frame_alloc()     */
-	#define NR_frame_free      44 /**< kernel_frame_free()      */
-	#define NR_upage_alloc     45 /**< kernel_upage_alloc()     */
-	#define NR_upage_free      46 /**< kernel_upage_free()      */
-	#define NR_upage_map       47 /**< kernel_upage_map()       */
-	#define NR_upage_link      48 /**< kernel_upage_link()      */
-	#define NR_upage_unlink    49 /**< kernel_upage_unlink()    */
-	#define NR_upage_unmap     50 /**< kernel_upage_unmap()     */
-	#define NR_excp_ctrl       51 /**< kernel_excp_ctrl()       */
-	#define NR_excp_pause      52 /**< kernel_excp_pause()      */
-	#define NR_excp_resume     53 /**< kernel_excp_resume()     */
-	#define NR_cluster_get_num 54 /**< kernel_cluster_get_num() */
-	#define NR_comm_get_port   55 /**< kernel_comm_get_port()   */
+	#define NR__exit             1 /**< kernel_exit()             */
+	#define NR_write             2 /**< kernel_write()            */
+	#define NR_thread_get_id     3 /**< kernel_thread_get_id()    */
+	#define NR_thread_create     4 /**< kernel_thread_create()    */
+	#define NR_thread_exit       5 /**< kernel_thread_exit()      */
+	#define NR_thread_join       6 /**< kernel_thread_join()      */
+	#define NR_thread_yield      7 /**< kernel_thread_yield()     */
+	#define NR_sleep             8 /**< kernel_sleep()            */
+	#define NR_wakeup            9 /**< kernel_wakeup()           */
+	#define NR_shutdown         10 /**< kernel_shutdown()         */
+	#define NR_sigctl           11 /**< kernel_sigctl()           */
+	#define NR_alarm            12 /**< kernel_alarm()            */
+	#define NR_sigsend          13 /**< kernel_sigsend()          */
+	#define NR_sigwait          14 /**< kernel_sigwait()          */
+	#define NR_sigreturn        15 /**< kernel_sigreturn()        */
+	#define NR_node_get_num     16 /**< kernel_node_get_num()     */
+	#define NR_sync_create      17 /**< kernel_sync_create()      */
+	#define NR_sync_open        18 /**< kernel_sync_open()        */
+	#define NR_sync_unlink      19 /**< kernel_sync_unlink()      */
+	#define NR_sync_close       20 /**< kernel_sync_close()       */
+	#define NR_sync_wait        21 /**< kernel_sync_wait()        */
+	#define NR_sync_signal      22 /**< kernel_sync_signal()      */
+	#define NR_sync_ioctl       23 /**< kernel_sync_ioctl()       */
+	#define NR_mailbox_create   24 /**< kernel_mailbox_create()   */
+	#define NR_mailbox_open     25 /**< kernel_mailbox_open()     */
+	#define NR_mailbox_unlink   26 /**< kernel_mailbox_unlink()   */
+	#define NR_mailbox_close    27 /**< kernel_mailbox_close()    */
+	#define NR_mailbox_awrite   28 /**< kernel_mailbox_awrite()   */
+	#define NR_mailbox_aread    29 /**< kernel_mailbox_aread()    */
+	#define NR_mailbox_wait     30 /**< kernel_mailbox_wait()     */
+	#define NR_mailbox_ioctl    31 /**< kernel_mailbox_ioctl()    */
+	#define NR_portal_create    32 /**< kernel_portal_create()    */
+	#define NR_portal_allow     33 /**< kernel_portal_allow()     */
+	#define NR_portal_open      34 /**< kernel_portal_open()      */
+	#define NR_portal_unlink    35 /**< kernel_portal_unlink()    */
+	#define NR_portal_close     36 /**< kernel_portal_close()     */
+	#define NR_portal_awrite    37 /**< kernel_portal_awrite()    */
+	#define NR_portal_aread     38 /**< kernel_portal_aread()     */
+	#define NR_portal_wait      39 /**< kernel_portal_wait()      */
+	#define NR_portal_ioctl     40 /**< kernel_portal_ioctl()     */
+	#define NR_clock            42 /**< kernel_clock()            */
+	#define NR_stats            43 /**< kernel_stats()            */
+	#define NR_frame_alloc      44 /**< kernel_frame_alloc()      */
+	#define NR_frame_free       45 /**< kernel_frame_free()       */
+	#define NR_upage_alloc      46 /**< kernel_upage_alloc()      */
+	#define NR_upage_free       47 /**< kernel_upage_free()       */
+	#define NR_upage_map        48 /**< kernel_upage_map()        */
+	#define NR_upage_link       49 /**< kernel_upage_link()       */
+	#define NR_upage_unlink     50 /**< kernel_upage_unlink()     */
+	#define NR_upage_unmap      51 /**< kernel_upage_unmap()      */
+	#define NR_excp_ctrl        52 /**< kernel_excp_ctrl()        */
+	#define NR_excp_pause       53 /**< kernel_excp_pause()       */
+	#define NR_excp_resume      54 /**< kernel_excp_resume()      */
+	#define NR_cluster_get_num  55 /**< kernel_cluster_get_num()  */
+	#define NR_comm_get_port    56 /**< kernel_comm_get_port()    */
 
-	#define NR_last_kcall      56 /**< NR_SYSCALLS definer      */
+	#define NR_last_kcall       57 /**< NR_SYSCALLS definer      */
 	/**@}*/
 
 /*============================================================================*
@@ -125,6 +125,7 @@
 	EXTERN int kernel_thread_join(int, void **);
 	EXTERN int kernel_sleep(void);
 	EXTERN int kernel_wakeup(int);
+	EXTERN int kernel_thread_yield(void);
 
 	/**
 	 * @brief Shutdowns the kernel.

--- a/src/kernel/init/main.c
+++ b/src/kernel/init/main.c
@@ -97,6 +97,8 @@ PUBLIC void kmain(int argc, const char *argv[])
 	network_setup();
 #endif
 
+	thread_init();
+
 #if (CLUSTER_IS_MULTICORE)
 	thread_create(&tid, init, NULL);
 	while (true)

--- a/src/kernel/pm/multithread.c
+++ b/src/kernel/pm/multithread.c
@@ -28,19 +28,12 @@
 #include <nanvix/const.h>
 #include <posix/errno.h>
 
+#if CORE_SUPPORTS_MULTITHREADING
+
 /**
  * @brief Number of thread_create trials.
  */
 #define THREAD_CREATE_NTRIALS 5
-
-/**
- * @name Number of threads.
- *
- * @details Master + Idles == SYS_THREAD_MAX.
- */
-/**@{*/
-#define IDLE_THREAD_MAX (SYS_THREAD_MAX - 1)
-/**@}*/
 
 /*
  * Import definitions.
@@ -113,6 +106,13 @@ PRIVATE spinlock_t lock_tm = SPINLOCK_UNLOCKED;
  * @warning Not use core 0 because it is not a idle thread.
  */
 #define IDLE_THREAD(coreid) (&threads[coreid])
+
+/**
+ * @brief Number of idle threads.
+ *
+ * @details Master + Idles == SYS_THREAD_MAX.
+ */
+#define IDLE_THREAD_MAX (SYS_THREAD_MAX - 1)
 
 /**
  * @brief Scheduler queue per core/idle thread.
@@ -787,4 +787,6 @@ PUBLIC void thread_init(void)
 
 #endif /* CLUSTER_IS_MULTICORE */
 }
+
+#endif /* CORE_SUPPORTS_MULTITHREADING */
 

--- a/src/kernel/pm/singlethread.c
+++ b/src/kernel/pm/singlethread.c
@@ -1,0 +1,439 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/hal.h>
+#include <nanvix/kernel/thread.h>
+#include <nanvix/const.h>
+#include <posix/errno.h>
+
+#if !CORE_SUPPORTS_MULTITHREADING
+
+/**
+ * @brief Number of thread_create trials.
+ */
+#define THREAD_CREATE_NTRIALS 5
+
+/*
+ * Import definitions.
+ */
+EXTERN void kmain(int argc, const char *argv[]);
+
+/**
+ * @brief Thread table.
+ */
+EXTENSION PUBLIC struct thread threads[KTHREAD_MAX] = {
+	[0] = {
+		.tid = KTHREAD_MASTER_TID,
+		.coreid = 0,
+		.state = THREAD_RUNNING,
+		.arg = NULL,
+		.start = (void *) kmain,
+		.next = NULL
+	},
+#if CLUSTER_IS_MULTICORE
+	[1 ... (KTHREAD_MAX - 1)] = {.tid = KTHREAD_NULL_TID, .state = THREAD_NOT_STARTED}
+#endif
+} ;
+
+#if CLUSTER_IS_MULTICORE
+
+/**
+ * @brief Thread join conditions.
+ */
+EXTENSION PRIVATE struct condvar joincond[KTHREAD_MAX] = {
+	[0 ... (KTHREAD_MAX - 1)] = COND_INITIALIZER
+};
+
+/**
+ * @brief Number of running threads.
+ */
+PRIVATE int nthreads = 1;
+
+/**
+ * @brief Next thread ID.
+ */
+PRIVATE int next_tid = (KTHREAD_MASTER_TID + 1);
+
+/**
+ * @brief Thread manager lock.
+ */
+PRIVATE spinlock_t lock_tm = SPINLOCK_UNLOCKED;
+
+/*============================================================================*
+ * thread_get_curr()                                                          *
+ *============================================================================*/
+
+/**
+* @brief Gets the currently running thread.
+*
+* The thread_get() function returns a pointer to the thread
+* that is running in the underlying core.
+*
+* @returns A pointer to the thread that is running in the
+* underlying core.
+*/
+PUBLIC struct thread *thread_get_curr(void)
+{
+	int mycoreid; /* Core ID. */
+
+	mycoreid = core_get_id();
+
+	for (int i = 0; i < KTHREAD_MAX; i++)
+	{
+		/* Found. */
+		if (threads[i].coreid == mycoreid)
+			return (&threads[i]);
+	}
+
+	/* Should not happen. */
+	return (NULL);
+}
+
+/*============================================================================*
+ * thread_alloc()                                                             *
+ *============================================================================*/
+
+/**
+ * @brief Allocates a thread.
+ *
+ * The thread_alloc() function allocates a new thread structure in the
+ * table of threads.
+ *
+ * @returns Upon successful completion, a pointer to the newly
+ * allocated thread is returned. Upon failure, a NULL pointer is
+ * returned instead.
+ *
+ * @note This function is NOT thread-safe.
+ *
+ * @author Pedro Henrique Penna
+ */
+PRIVATE struct thread *thread_alloc(void)
+{
+	for (int i = 1; i < KTHREAD_MAX; i++)
+	{
+		/* Found. */
+		if (threads[i].state == THREAD_NOT_STARTED)
+		{
+			struct thread *new_thread;
+			new_thread = &threads[i];
+			new_thread->coreid = i;
+			new_thread->state = THREAD_STARTED;
+			nthreads++;
+
+			return (new_thread);
+		}
+	}
+
+	return (NULL);
+}
+
+/*============================================================================*
+ * thread_free()                                                              *
+ *============================================================================*/
+
+/**
+ * @brief Releases a thread.
+ *
+ * The thread_free() function releases the thread entry pointed to by
+ * @p t in the table of threads.
+ *
+ * @note This function is NOT thread-safe.
+ *
+ * @author Pedro Henrique Penna
+ */
+PRIVATE void thread_free(struct thread *t)
+{
+	KASSERT(t >= &threads[0]);
+	KASSERT(t <= &threads[KTHREAD_MAX - 1]);
+
+	t->coreid = -1;
+	t->state = THREAD_NOT_STARTED;
+	t->tid = KTHREAD_NULL_TID;
+	nthreads--;
+}
+
+/*============================================================================*
+ * thread_exit()                                                              *
+ *============================================================================*/
+
+/**
+ * The thread_exit() function terminates the calling thread. It first
+ * releases all underlying kernel resources that are linked to the
+ * thread and then resets the underlying core. The return value of the
+ * thread, which is pointed to by @p retval, is made available for a
+ * thread that joins this one.
+ *
+ * @note This function does not return.
+ * @note This function is thread-safe.
+ *
+ * @see thread_join().
+ *
+ * @author Pedro Henrique Penna
+ */
+PUBLIC NORETURN void thread_exit(void *retval)
+{
+	int mycoreid;
+	struct thread *curr_thread;
+
+	UNUSED(retval);
+
+	/* Indicates that the underlying core will be reset. */
+	KASSERT(core_release() == 0);
+
+		curr_thread = thread_get_curr();
+		mycoreid = thread_get_coreid(curr_thread);
+
+		spinlock_lock(&lock_tm);
+			thread_free(curr_thread);
+			cond_broadcast(&joincond[mycoreid]);
+		spinlock_unlock(&lock_tm);
+
+	/* No rollback after this point. */
+	/* Resets the underlying core. */
+	core_reset();
+
+	/* Never gets here. */
+	UNREACHABLE();
+}
+
+/*============================================================================*
+ * thread_get()                                                               *
+ *============================================================================*/
+
+/**
+ * @brief Returns the target thread.
+ *
+ * The thread_get() function performs a linear search in the table of
+ * threads for the thread whose ID equals to @p tid.
+ *
+ * @param tid ID of the target thread.
+ *
+ * @returns Upon successful completion, a pointer to the target thread
+ * is returned. Upon failure, a null pointed is returned instead.
+ *
+ * @note This function is NOT thread safe.
+ */
+PRIVATE struct thread *thread_get(int tid)
+{
+	/* Sanity check. */
+	KASSERT(tid > KTHREAD_NULL_TID);
+
+	/* Search for target thread. */
+	for (int i = 0; i < KTHREAD_MAX; i++)
+	{
+		/* Found. */
+		if (threads[i].tid == tid)
+			return (&threads[i]);
+	}
+
+	return (NULL);
+}
+
+/*============================================================================*
+ * thread_start()                                                             *
+ *============================================================================*/
+
+/**
+ * @brief Starts a thread.
+ *
+ * The thread_start function is a wrapper routine for the user-level
+ * thread start routine. Overall, it does some basic, kernel level
+ * setup and calls the registered user-level function.
+ *
+ * @note This function does not return.
+ *
+ * @author Pedro Henrique Penna
+ */
+PRIVATE NORETURN void thread_start(void)
+{
+	void *retval;               /* Return value.   */
+	struct thread *curr_thread; /* Current thread. */
+
+	curr_thread = thread_get_curr();
+
+	retval = curr_thread->start(curr_thread->arg);
+
+	thread_exit(retval);
+
+	/* Never gets here. */
+	UNREACHABLE();
+}
+
+/*============================================================================*
+ * thread_create()                                                            *
+ *============================================================================*/
+
+/**
+ * The thread_create() function create and starts a new thread. The
+ * new thread executes the start routine pointed to by @p start, with
+ * @p arg begin passed as argument to this function. If @p tid is not
+ * a NULL pointed, the ID of the new thread is stored into the
+ * location pointed to by @p tid.
+ *
+ * @retval -EAGAIN Not enough resources to allocate a new thread.
+ *
+ * @note This function is thread safe.
+ *
+ * @author Pedro Henrique Penna
+ */
+PUBLIC int thread_create(int *tid, void*(*start)(void*), void *arg)
+{
+	int ret;                   /* Return value.             */
+	int _tid;                  /* Unique thread identifier. */
+	struct thread *new_thread; /* New thread.               */
+	int ntrials = 0;           /* Trials realized.          */
+
+	/* Sanity check. */
+	KASSERT(start != NULL);
+
+	spinlock_lock(&lock_tm);
+
+		/* Allocate thread. */
+		new_thread = thread_alloc();
+		if (new_thread == NULL)
+		{
+			kprintf("[pm] cannot create thread");
+			spinlock_unlock(&lock_tm);
+			return (-EAGAIN);
+		}
+
+		/* Get thread ID. */
+		_tid = next_tid++;
+
+		/* Initialize thread structure. */
+		new_thread->tid   = _tid;
+		new_thread->state = THREAD_RUNNING;
+		new_thread->arg   = arg;
+		new_thread->start = start;
+		new_thread->next  = NULL;
+
+	spinlock_unlock(&lock_tm);
+
+	/* Save thread ID. */
+	if (tid != NULL)
+	{
+		*tid = _tid;
+		dcache_invalidate();
+	}
+
+	/*
+	 * We should do some busy waitting here. When the kernel is under
+	 * stress, there is a chance that we allocate a core that is in
+	 * RUNNING state. That happens because a previous thread running
+	 * on this core has existed and we have joined it, but the
+	 * terminated thread hasn't had enough time to issue issue a
+	 * core_reset().
+	 */
+	do
+	{
+		ret = core_start(thread_get_coreid(new_thread), thread_start);
+		ntrials++;
+	} while (ret == -EBUSY && ntrials < THREAD_CREATE_NTRIALS);
+
+
+	/* Rollback. */
+	if (ret != 0)
+	{
+		spinlock_lock(&lock_tm);
+			thread_free(new_thread);
+		spinlock_unlock(&lock_tm);
+	}
+
+	return (ret);
+}
+
+/*============================================================================*
+ * thread_join()                                                              *
+ *============================================================================*/
+
+/**
+ * The thread_join() function causes the calling thread to block until
+ * the thread whose ID equals to @p tid its terminates execution, by
+ * calling thread_exit(). If @p retval is not a null pointed, then the
+ * return value of the terminated thread is stored in the location
+ * pointed to by @p retval.
+ *
+ * @retval -EINVAL Invalid thread ID.
+ *
+ * @see thread_exit().
+ *
+ * @todo Retrieve return value.
+ */
+PUBLIC int thread_join(int tid, void **retval)
+{
+	int ret;
+	struct thread *t;
+
+	/* Sanity check. */
+	KASSERT(tid > KTHREAD_NULL_TID);
+	KASSERT(tid != thread_get_id(thread_get_curr()));
+	KASSERT(tid != KTHREAD_MASTER_TID);
+
+	UNUSED(retval);
+
+	spinlock_lock(&lock_tm);
+
+		/* Wait for thread termination. */
+		if ((t = thread_get(tid)) != NULL)
+		{
+			int coreid;
+
+			coreid = thread_get_coreid(t);
+
+			/*
+			 * The target thread is still running,
+			 * so we have to block and wait for it.
+			 */
+			if (t->state == THREAD_RUNNING)
+				cond_wait(&joincond[coreid], &lock_tm);
+		}
+
+		/*
+		 * Thread IDs are incremented by next_id. So, if we want to know
+		 * if the @p tid is valid and has already left, just check if it
+		 * is less than the next_tid.
+		 */
+		ret = (tid < next_tid) ? 0 : (-EINVAL);
+
+	spinlock_unlock(&lock_tm);
+
+	return (ret);
+}
+
+#endif /* CLUSTER_IS_MULTICORE */
+
+/*============================================================================*
+ * thread_init()                                                              *
+ *============================================================================*/
+
+/**
+ * @brief Dummy Initialize thread system.
+ */
+PUBLIC void thread_init(void)
+{
+
+}
+
+#endif /* "CORE_SUPPORTS_MULTITHREADING */
+

--- a/src/kernel/sys/sleep.c
+++ b/src/kernel/sys/sleep.c
@@ -40,7 +40,7 @@ EXTENSION PRIVATE struct
 	struct condvar cond;
 } queues[KTHREAD_MAX] = {
 	[0 ... (KTHREAD_MAX - 1)] = {
-		.tid = -1,
+		.tid  = KTHREAD_NULL_TID,
 		.cond = COND_INITIALIZER
 	},
 };

--- a/src/kernel/sys/syscalls.c
+++ b/src/kernel/sys/syscalls.c
@@ -416,6 +416,10 @@ PUBLIC int do_kcall(
 			);
 			break;
 
+		case NR_thread_yield:
+			ret = kernel_thread_yield();
+			break;
+
 		case NR_sleep:
 			ret = kernel_sleep();
 			break;

--- a/src/kernel/sys/thread.c
+++ b/src/kernel/sys/thread.c
@@ -116,10 +116,32 @@ PUBLIC int kernel_thread_join(int tid, void **retval)
 		return (-EINVAL);
 
 	/* Cannot join master thread. */
-	if (tid == KTHREAD_MASTER_TID)
+	if (WITHIN(tid, 0, SYS_THREAD_MAX))
 		return (-EINVAL);
 
 	return (thread_join(tid, retval));
+}
+
+/*============================================================================*
+ * kernel_thread_yield()                                                      *
+ *============================================================================*/
+
+/**
+ * @see thread_yield().
+ *
+ * @retval -EINVAL Failed to release the core.
+ */
+PUBLIC int kernel_thread_yield(void)
+{
+	/* Invalid thread. */
+	if (thread_get_id(thread_get_curr()) == KTHREAD_MASTER_TID)
+		return (-EINVAL);
+
+#if CORE_SUPPORTS_MULTITHREADING
+	return (thread_yield());
+#else
+	return (-ENOSYS);
+#endif
 }
 
 #endif


### PR DESCRIPTION
## Description

In this PR, I implement a thread scheduler used on architecture that supports multithreading (see `CORE_SUPPORTS_MULTITHREADING` constant in nanvix/hal).

Briefly, I add the following changes:
- Rename the old thread management file from `pm/thread.c` to `pm/singlethread.c`
- Modify the single thread management to use `context_create` and `context_switch_to` functions to perform the schedule of user thread. This makes it possible to have more user threads than physical cores. The implementation is in the `pm/multithread.c` file.
- Add the `thread_yield` function to allow threads to voluntarily yield the core to another thread.

## Related Submodule PRs

[[core] Feature: Introduce context switching mechanism #621](https://github.com/nanvix/hal/pull/621)

## Related issue

Closes #226