### PR TITLE
[ikc] Reset Communication Parameters When Mailbox Read Completes

### DIFF
--- a/src/kernel/noc/vmailbox.c
+++ b/src/kernel/noc/vmailbox.c
@@ -299,7 +299,17 @@ PUBLIC int do_vmailbox_awrite(int mbxid, const void * buffer, size_t size)
  */
 PUBLIC int do_vmailbox_wait(int mbxid)
 {
-	return (communicator_wait(&vmailboxes[mbxid]));
+	int ret; /* Return value. */
+
+	/* Wait for the operation to complete. */
+	if ((ret = communicator_wait(&vmailboxes[mbxid])) == ACTIVE_COMM_SUCCESS)
+	{
+		/* Reset remote. */
+		if (resource_is_readable(&vmailboxes[mbxid].resource))
+			vmailboxes[mbxid].config.remote_addr = (-1);
+	}
+
+	return (ret);
 }
 
 /*============================================================================*


### PR DESCRIPTION
In this PR, I reset the remote address every time that a mailbox read is completed.
Before this fix, an application could set a specific address that's will be not reset, introducing a deadlock.