### PR TITLE
[ikc][bugfix] New Security Check to IOCTL Set Remote Operation

### DIFF
--- a/src/kernel/noc/communicator.c
+++ b/src/kernel/noc/communicator.c
@@ -387,6 +387,10 @@ PUBLIC int communicator_ioctl(
 				if (!resource_is_readable(&comm->resource))
 					goto error;
 
+				/* Remote already set? */
+				if (comm->config.remote_addr != -1)
+					goto error;
+
 				comm->config.remote_addr = comm->fn->laddress_calc(nodenum, port_nr);
 
 				ret = 0;


### PR DESCRIPTION
# Description #
In this PR, a new security check is added to the Set_Remote IOCTL operation, to avoid a double Set_Remote, or applying this operation for input portals, which would be erroneous.