### PR TITLE
[pm] Enter a Panic state if the master thread throws an exception.

### DIFF
--- a/src/kernel/pm/exception.c
+++ b/src/kernel/pm/exception.c
@@ -223,6 +223,12 @@ PUBLIC int exception_wait(int excpnum, const struct exception *excp)
 	t = thread_get_curr();
 	coreid = thread_get_coreid(t);
 
+	if (UNLIKELY(t == KTHREAD_MASTER))
+	{
+		exception_dump(excp);
+		kpanic("[kernel][excp] The master thread throws an exception within the kernel space!");
+	}
+
 	spinlock_lock(&lock);
 
 		/* Chek if exception is being ignored. */


### PR DESCRIPTION
In this PR, I add a check that verifies if the master thread tries to wait for exception treatment. If it is true, then we enter a _kernel panic_ state.

### Resolved Issue

Closes #296 