### PR TITLE
[kernel] Wrong Bitmap Check on Page Frame Allocation

### DIFF
--- a/src/kernel/mm/frame/mod.c
+++ b/src/kernel/mm/frame/mod.c
@@ -69,7 +69,7 @@ static int frame_alloc(frame_t frame)
     const bitmap_t bit = frame;
 
     // Check wether or not the target page frame is available.
-    if (bitmap_check_bit(frames, bit) == 1) {
+    if (bitmap_check_bit(frames, bit) != 0) {
         kprintf(MODULE_NAME " ERROR: busy frame (frame=%x)", frame);
         return (-1);
     }


### PR DESCRIPTION
## Description

This PR fixes the bug we were performing a bad check when allocating page frames.