### PR TITLE
[kernel] F: Log subsystem

### DIFF
--- a/include/nanvix/kernel/log.h
+++ b/include/nanvix/kernel/log.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) 2011-2023 The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef NANVIX_KERNEL_LOG_H_
+#define NANVIX_KERNEL_LOG_H_
+
+/*============================================================================*
+ * Imports                                                                    *
+ *============================================================================*/
+
+#include <stdarg.h>
+
+/*============================================================================*
+ * Constants                                                                  *
+ *============================================================================*/
+
+/* Log message levels */
+#define DEBUG 0 /** Debug level.       */
+#define ERROR 1 /** Error level.       */
+#define INFO 2  /** Information level. */
+#define TRACE 3 /** Trace level.       */
+#define WARN 4  /** Warning level.     */
+
+/*============================================================================*
+ * Functions                                                                  *
+ *============================================================================*/
+
+/**
+ * @brief Prints a log message to the standard output.
+ *
+ * @details For the log message to be fully printed it must not contain more
+ * than `LOG_BUFFER_SIZE` characters.
+ *
+ * @param file A string defined by the macro `__FILE__`.
+ * @param funcname A string defined by the macro `__func__`.
+ * @param level The log message level e.g. `INFO`.
+ *
+ * @return Zero for a successful completion.  Upon failure, an negative number
+ * will be returned instead.
+ */
+extern int __log(const char *file, const char *funcname, unsigned level, ...);
+
+/**
+ * @brief Prints a custom log message to the standard output.
+ *
+ * @param level The log message level e.g. `INFO`.
+ */
+#define log(level, ...) do_log(__FILE__, __func__, level, __VA_ARGS__)
+
+#endif /* NANVIX_KERNEL_LOG_H_ */

--- a/src/kernel/Makefile
+++ b/src/kernel/Makefile
@@ -14,6 +14,7 @@ SRC_C = $(wildcard hal/arch/*.c)      \
 		$(wildcard hal/*.c)           \
 		$(wildcard kcall/*.c)         \
 		$(wildcard lib/*.c)           \
+		$(wildcard log/*.c)           \
 		$(wildcard pm/*.c)            \
 		$(wildcard mm/frame/*.c)      \
 		$(wildcard mm/kpool/*.c)      \

--- a/src/kernel/log/log.c
+++ b/src/kernel/log/log.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright(c) 2011-2023 The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*============================================================================*
+ * Imports                                                                    *
+ *============================================================================*/
+
+#include <nanvix/kernel/lib.h>
+#include <nanvix/kernel/log.h>
+#include <nanvix/libcore.h>
+#include <stddef.h>
+
+/*============================================================================*
+ * Constants                                                                  *
+ *============================================================================*/
+
+/**
+ * @brief Number of log message levels.
+ */
+#define LOG_LEVEL_MAX 5
+
+/**
+ * @brief Buffer size (in bytes).
+ */
+#define LOG_BUFFER_SIZE 128
+
+/**
+ * @brief Log module scope.
+ */
+#define LOG_MODULE_SCOPE "[kernel]"
+
+/**
+ * @brief Message levels.
+ */
+static const char *MSG_LEVEL[LOG_LEVEL_MAX] = {
+    "[DEBUG]", "[ERROR]", "[INFO]", "[TRACE]", "[WARN]"};
+
+/*============================================================================*
+ * Private Variables                                                          *
+ *============================================================================*/
+
+/**
+ * @brief Message buffer.
+ */
+static char buffer[LOG_BUFFER_SIZE + 1];
+
+/*============================================================================*
+ * Private Functions                                                          *
+ *============================================================================*/
+
+/**
+ * @brief Checks if the buffer can fit `ins_size` characters,
+ * if not prints the current filled buffer.
+ *
+ * @param buf_pos The next position to be inserted in the buffer.
+ * @param ins_size The number of characters to be inserted in the buffer.
+ *
+ * @return The next position to be inserted in the buffer.
+ *
+ */
+static size_t chkbuf(size_t buf_pos, size_t ins_size)
+{
+    if (buf_pos > LOG_BUFFER_SIZE) {
+        buffer[LOG_BUFFER_SIZE] = '\0';
+        kputs(buffer);
+        buf_pos = 0;
+    } else if (buf_pos + ins_size > LOG_BUFFER_SIZE) {
+        buffer[buf_pos] = '\0';
+        kputs(buffer);
+        buf_pos = 0;
+    }
+
+    return (buf_pos);
+}
+
+/**
+ * @brief Copies a string content to the buffer (without `\0`).
+ *
+ * @details The fuction calls `chkbuf()`,
+ * thus it shall print the buffer to the standard output if the buffer is full.
+ *
+ * @param s The source string to be copied.
+ * @param i The position within the buffer to be inserted.
+ *
+ * @return The next position to be inserted in the buffer.
+ *
+ */
+static size_t cpy2buf(const char *s, size_t i)
+{
+    for (size_t j = 0; s[j] != '\0'; j++) {
+        i = chkbuf(i, 1);
+        buffer[i++] = s[j];
+    }
+
+    return (i);
+}
+
+/**
+ * @brief Inserts module name and message level in the log message.
+ *
+ * @param file A string defined by the macro `__FILE__`.
+ * @param funcname A string defined by the macro `__func__`.
+ * @param level The log message level.
+ *
+ * @return The next position to be inserted in the buffer.
+ */
+static size_t fmt_prefix(const char *file, const char *funcname, int level)
+{
+    size_t i = 0;
+
+    // Inserts message level.
+    i = cpy2buf(MSG_LEVEL[level], i);
+
+    // Inserts module name.
+    i = cpy2buf(LOG_MODULE_SCOPE, i);
+    buffer[i++] = '[';
+    for (size_t j = 0; file[j + 2] != '\0'; j++) {
+        i = chkbuf(i, 1);
+        if (file[j] == '/') {
+            buffer[i++] = ']';
+            buffer[i++] = '[';
+        } else {
+            buffer[i++] = file[j];
+        }
+    }
+    buffer[i++] = ']';
+
+    // Inserts function name.
+    i = chkbuf(i, __strlen(funcname) + 6);
+    buffer[i++] = ' ';
+    i = cpy2buf(funcname, i);
+    i = cpy2buf("(): ", i);
+
+    return (i);
+}
+
+/*============================================================================*
+ * Public Functions                                                           *
+ *============================================================================*/
+
+/**
+ * @details Prints a log message to the standard output.
+ */
+int __log(const char *file, const char *funcname, unsigned level, ...)
+{
+    // Validades arguments.
+    if (file == NULL || funcname == NULL || level >= LOG_LEVEL_MAX) {
+        return -1;
+    }
+
+    va_list args;                                 // Variable arguments list
+    size_t i = fmt_prefix(file, funcname, level); // String length.
+
+    va_start(args, level);
+
+    // Print message into the buffer.
+    const char *fmt_str = va_arg(args, char *);
+    i = chkbuf(i, __strlen(fmt_str));
+    i += __vsnprintf(buffer + i, LOG_BUFFER_SIZE - (i + 1), fmt_str, args);
+
+    // Terminate string.
+    buffer[++i] = '\n';
+    buffer[++i] = '\0';
+
+    va_end(args);
+    kputs(buffer);
+
+    return (0);
+}


### PR DESCRIPTION
### Initial kernel log subsystem implementation

The kernel log subsystem is declared in the header file `<nanvix/kernel/log.h>`.

It is exposed through the `log()` macro that recieves one of the five avaible message levels (`DEBUG`, `ERROR`, `INFO`, `TRACE`, `WARN`) and a format string with a message.

The message is printed to the standard output and shall follow the behaviour specified in issue #352. 



