### PR TITLE
Fix attempt of `process_exit()` causing a use after free

### DIFF
--- a/src/kernel/pm/process.c
+++ b/src/kernel/pm/process.c
@@ -236,8 +236,10 @@ void process_yield(void)
  */
 noreturn void process_exit(void)
 {
+    KASSERT(running != kernel);
     running->state = PROCESS_TERMINATED;
     process_free(running);
+    running = kernel;
     process_yield();
     UNREACHABLE();
 }


### PR DESCRIPTION
Attempt of fixing the problem described in the issue #393